### PR TITLE
fix: Docker イメージピン留め + コンテナ非root実行

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,10 @@ ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/release
 
 COPY --from=builder /app/build/libs/cache-service.jar app.jar
 
+RUN addgroup -S app && adduser -S app -G app && \
+    chown -R app:app /app
+USER app
+
 EXPOSE 8080
 ENTRYPOINT ["java", \
   "-javaagent:otel-agent.jar", \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   redis:
-    image: redis:alpine
+    image: redis:7.4-alpine
+    restart: unless-stopped
     # REDIS_PASSWORD が設定されている場合は認証を有効化する
     # 例: REDIS_PASSWORD=yourpassword docker compose up -d
     command: >
@@ -27,6 +28,7 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:
@@ -51,14 +53,16 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
-      - "80:80"
+      - "80:8080"
     depends_on:
       backend:
         condition: service_healthy
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    restart: unless-stopped
     volumes:
       - ./docker/otel-collector-config.yaml:/etc/otel/config.yaml
     command: ["--config=/etc/otel/config.yaml"]
@@ -69,7 +73,8 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:2.6
+    restart: unless-stopped
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,13 @@ RUN npm run build
 
 # Stage 2: Serve
 FROM nginx:alpine
+
+# 非root ユーザーで実行するための準備
+RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx/conf.d && \
+    touch /var/run/nginx.pid && chown nginx:nginx /var/run/nginx.pid
+
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+
+USER nginx
+EXPOSE 8080

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
## Summary
- Docker イメージをバージョン固定（redis:7.4-alpine, otel-collector:0.120.0, jaeger:2.6）
- backend/frontend コンテナを非root ユーザーで実行
- 全サービスに `restart: unless-stopped` 追加
- nginx を非root 対応のためポート 8080 にリッスン変更

## Test plan
- [ ] `docker compose up -d --build` で全サービス正常起動
- [ ] `docker compose ps` でイメージタグ確認
- [ ] `docker exec <backend> whoami` → `app` を確認
- [ ] `docker exec <frontend> whoami` → `nginx` を確認
- [ ] ブラウザで http://localhost アクセス確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)