### PR TITLE
fix: Nginx セキュリティヘッダー + パフォーマンス最適化

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,12 +3,31 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # セキュリティヘッダー
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    # gzip 圧縮
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 256;
+    gzip_vary on;
+
     # Docker 内部 DNS で upstream を動的に再解決する
     resolver 127.0.0.11 valid=5s ipv6=off;
     set $backend_upstream http://backend:8080;
 
     location / {
         try_files $uri $uri/ /index.html;
+    }
+
+    # 静的アセット（JS/CSS/画像）のキャッシュ
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
     }
 
     # SSE (Server-Sent Events) 専用: バッファリングを無効化して即時配信


### PR DESCRIPTION
## Summary
- セキュリティヘッダー追加（X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy）
- gzip 圧縮を有効化（text/JS/CSS/JSON/SVG 対象）
- 静的アセットに 1年間の Cache-Control（immutable）設定

## Test plan
- [ ] `curl -I http://localhost` でセキュリティヘッダー確認
- [ ] Chrome DevTools Network タブで gzip 圧縮確認
- [ ] 静的アセット（.js, .css）のレスポンスヘッダーに `Cache-Control: public, immutable` 確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)