### PR TITLE
test: フロントエンド未テスト9ページのテスト追加

### DIFF
--- a/frontend/src/test/pages/CircuitBreakerPage.test.tsx
+++ b/frontend/src/test/pages/CircuitBreakerPage.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CircuitBreakerPage } from '../../pages/CircuitBreakerPage'
+import type { HealthResponse } from '../../types/health'
+
+// Mock APIs
+vi.mock('../../api/cache', () => ({
+  cacheApi: {
+    simulateError: vi.fn(),
+    resetCircuitBreaker: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/health', () => ({
+  healthApi: {
+    get: vi.fn(),
+  },
+}))
+
+// Mock usePolling
+vi.mock('../../hooks/usePolling', () => ({
+  usePolling: vi.fn(),
+}))
+
+// Mock CircuitBreakerStateDiagram
+vi.mock('../../components/dashboard/CircuitBreakerStateDiagram', () => ({
+  CircuitBreakerStateDiagram: ({
+    state,
+    failureRate,
+    slowCallRate,
+  }: {
+    state: string
+    failureRate: number
+    slowCallRate: number
+  }) => (
+    <div
+      data-testid="circuit-breaker-state-diagram"
+      data-state={state}
+      data-failure-rate={failureRate}
+      data-slow-call-rate={slowCallRate}
+    />
+  ),
+}))
+
+// Mock recharts to avoid ResizeObserver and canvas issues in jsdom
+vi.mock('recharts', () => ({
+  RadialBarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="radial-bar-chart">{children}</div>
+  ),
+  RadialBar: () => <div data-testid="radial-bar" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+}))
+
+import { usePolling } from '../../hooks/usePolling'
+import { cacheApi } from '../../api/cache'
+
+const mockUsePolling = vi.mocked(usePolling)
+const mockSimulateError = vi.mocked(cacheApi.simulateError)
+const mockResetCircuitBreaker = vi.mocked(cacheApi.resetCircuitBreaker)
+
+const makeHealthData = (
+  state: 'CLOSED' | 'OPEN' | 'HALF_OPEN' = 'CLOSED',
+  failureRate = 0,
+  slowCallRate = 0
+): HealthResponse => ({
+  timestamp: new Date().toISOString(),
+  service: 'redis-app',
+  status: 'UP',
+  redis: { status: 'UP', initialized: true },
+  circuitBreakers: {
+    'cache-operations': {
+      state,
+      failureRate,
+      slowCallRate,
+      numberOfSuccessfulCalls: 10,
+      numberOfFailedCalls: 0,
+      numberOfSlowCalls: 0,
+    },
+  },
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CircuitBreakerPage />
+    </MemoryRouter>
+  )
+}
+
+describe('CircuitBreakerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSimulateError.mockResolvedValue({ simulationEnabled: true, timestamp: Date.now() })
+    mockResetCircuitBreaker.mockResolvedValue({
+      reset: true,
+      state: 'CLOSED',
+      timestamp: Date.now(),
+    })
+    mockUsePolling.mockReturnValue({
+      data: makeHealthData(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(screen.getByText('Circuit Breaker ステートマシン')).toBeInTheDocument()
+  })
+
+  it('renders CircuitBreakerStateDiagram', () => {
+    renderPage()
+    expect(screen.getByTestId('circuit-breaker-state-diagram')).toBeInTheDocument()
+  })
+
+  it('passes correct state prop to CircuitBreakerStateDiagram', () => {
+    mockUsePolling.mockReturnValue({
+      data: makeHealthData('CLOSED'),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    const diagram = screen.getByTestId('circuit-breaker-state-diagram')
+    expect(diagram).toHaveAttribute('data-state', 'CLOSED')
+  })
+
+  it('passes failure rate and slow call rate to diagram', () => {
+    mockUsePolling.mockReturnValue({
+      data: makeHealthData('OPEN', 60, 30),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    const diagram = screen.getByTestId('circuit-breaker-state-diagram')
+    expect(diagram).toHaveAttribute('data-failure-rate', '60')
+    expect(diagram).toHaveAttribute('data-slow-call-rate', '30')
+  })
+
+  it('shows loading state when data is not yet available', () => {
+    mockUsePolling.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+    expect(screen.queryByTestId('circuit-breaker-state-diagram')).not.toBeInTheDocument()
+  })
+
+  it('renders error injection toggle button', () => {
+    renderPage()
+    expect(screen.getByText('▶ エラー注入 ON')).toBeInTheDocument()
+  })
+
+  it('renders reset button', () => {
+    renderPage()
+    expect(screen.getByText('↺ サーキットブレーカー リセット')).toBeInTheDocument()
+  })
+
+  it('calls cacheApi.simulateError(true) when toggle button is clicked', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('▶ エラー注入 ON'))
+    await waitFor(() => {
+      expect(mockSimulateError).toHaveBeenCalledWith(true)
+    })
+  })
+
+  it('toggles button label to OFF after enabling simulation', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('▶ エラー注入 ON'))
+    await waitFor(() => {
+      expect(screen.getByText('⏹ エラー注入 OFF')).toBeInTheDocument()
+    })
+  })
+
+  it('calls cacheApi.simulateError(false) when toggle is clicked again to disable', async () => {
+    mockSimulateError.mockResolvedValueOnce({ simulationEnabled: true, timestamp: Date.now() })
+    renderPage()
+    // Enable first
+    fireEvent.click(screen.getByText('▶ エラー注入 ON'))
+    await waitFor(() => screen.getByText('⏹ エラー注入 OFF'))
+    // Disable
+    mockSimulateError.mockResolvedValueOnce({ simulationEnabled: false, timestamp: Date.now() })
+    fireEvent.click(screen.getByText('⏹ エラー注入 OFF'))
+    await waitFor(() => {
+      expect(mockSimulateError).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('calls cacheApi.resetCircuitBreaker when reset button is clicked', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('↺ サーキットブレーカー リセット'))
+    await waitFor(() => {
+      expect(mockResetCircuitBreaker).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows success message after reset', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('↺ サーキットブレーカー リセット'))
+    await waitFor(() => {
+      expect(screen.getByText('サーキットブレーカーをリセットしました')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when simulateError throws', async () => {
+    mockSimulateError.mockRejectedValue(new Error('network error'))
+    renderPage()
+    fireEvent.click(screen.getByText('▶ エラー注入 ON'))
+    await waitFor(() => {
+      expect(screen.getByText('操作に失敗しました')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when reset throws', async () => {
+    mockResetCircuitBreaker.mockRejectedValue(new Error('network error'))
+    renderPage()
+    fireEvent.click(screen.getByText('↺ サーキットブレーカー リセット'))
+    await waitFor(() => {
+      expect(screen.getByText('リセットに失敗しました')).toBeInTheDocument()
+    })
+  })
+
+  it('disables buttons while action is loading', async () => {
+    // Never-resolving promise keeps the button in loading state
+    mockSimulateError.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    const toggleBtn = screen.getByText('▶ エラー注入 ON')
+    fireEvent.click(toggleBtn)
+    await waitFor(() => {
+      expect(toggleBtn).toBeDisabled()
+      expect(screen.getByText('↺ サーキットブレーカー リセット')).toBeDisabled()
+    })
+  })
+
+  it('calls usePolling with 2000ms interval', () => {
+    renderPage()
+    expect(mockUsePolling).toHaveBeenCalledWith(
+      expect.objectContaining({ interval: 2000 })
+    )
+  })
+
+  it('displays current state label in the control panel', () => {
+    mockUsePolling.mockReturnValue({
+      data: makeHealthData('OPEN', 75, 20),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    expect(screen.getByText('OPEN')).toBeInTheDocument()
+  })
+
+  it('displays failure rate value', () => {
+    mockUsePolling.mockReturnValue({
+      data: makeHealthData('OPEN', 42.5, 0),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    expect(screen.getByText('42.5%')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/pages/LockDemoPage.test.tsx
+++ b/frontend/src/test/pages/LockDemoPage.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { LockDemoPage } from '../../pages/LockDemoPage'
+import type { LockDemoResponse } from '../../types/locks'
+
+// Mock locksApi
+vi.mock('../../api/locks', () => ({
+  locksApi: {
+    runDemo: vi.fn(),
+  },
+}))
+
+// Mock LockTimelineChart to avoid recharts rendering complexity
+vi.mock('../../components/locks/LockTimelineChart', () => ({
+  LockTimelineChart: ({ title }: { title: string }) => (
+    <div data-testid="lock-timeline-chart">{title}</div>
+  ),
+}))
+
+import { locksApi } from '../../api/locks'
+
+const mockRunDemo = vi.mocked(locksApi.runDemo)
+
+const makeModeResult = (correct: boolean) => ({
+  initialValue: 10,
+  expectedFinal: 6,
+  actualFinal: correct ? 6 : 8,
+  lostUpdates: correct ? 0 : 2,
+  correct,
+  events: [
+    { workerId: 1, step: 'READ' as const, value: 10, relativeMs: 0 },
+    { workerId: 1, step: 'WRITE' as const, value: 9, relativeMs: 5 },
+  ],
+})
+
+const mockDemoResponse: LockDemoResponse = {
+  withoutLock: makeModeResult(false),
+  withLock: makeModeResult(true),
+  timestamp: Date.now(),
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/locks/demo']}>
+      <Routes>
+        <Route path="/locks/demo" element={<LockDemoPage />} />
+        <Route path="/locks" element={<div>lock-monitor-page</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('LockDemoPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunDemo.mockResolvedValue(mockDemoResponse)
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(screen.getByText('分散ロック デモ')).toBeInTheDocument()
+  })
+
+  it('renders back button and navigates to /locks', () => {
+    renderPage()
+    // The back button contains "ロックモニター" text
+    fireEvent.click(screen.getByText('ロックモニター'))
+    expect(screen.getByText('lock-monitor-page')).toBeInTheDocument()
+  })
+
+  it('shows worker count slider with default value 4', () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    // First slider is workers
+    expect(sliders[0]).toHaveValue('4')
+  })
+
+  it('shows initial value slider with default value 10', () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    // Second slider is initialValue
+    expect(sliders[1]).toHaveValue('10')
+  })
+
+  it('shows worker count label with default value', () => {
+    renderPage()
+    // "ワーカー数: 4" label contains the bold value
+    expect(screen.getByText(/ワーカー数/)).toBeInTheDocument()
+  })
+
+  it('updates worker count when slider is changed', () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[0], { target: { value: '6' } })
+    expect(sliders[0]).toHaveValue('6')
+  })
+
+  it('updates initial value when slider is changed', () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[1], { target: { value: '20' } })
+    expect(sliders[1]).toHaveValue('20')
+  })
+
+  it('renders "デモを実行" button', () => {
+    renderPage()
+    expect(screen.getByText('デモを実行')).toBeInTheDocument()
+  })
+
+  it('calls locksApi.runDemo with default params when button is clicked', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(mockRunDemo).toHaveBeenCalledWith({ workers: 4, initialValue: 10 })
+    })
+  })
+
+  it('calls locksApi.runDemo with updated params', async () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[0], { target: { value: '6' } })
+    fireEvent.change(sliders[1], { target: { value: '20' } })
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(mockRunDemo).toHaveBeenCalledWith({ workers: 6, initialValue: 20 })
+    })
+  })
+
+  it('shows button as "実行中..." while running', async () => {
+    // Never-resolving promise so the button stays in loading state
+    mockRunDemo.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(screen.getByText('実行中...')).toBeInTheDocument()
+    })
+  })
+
+  it('shows result panels after successful API call', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(screen.getByText('ロックなし（競合あり）')).toBeInTheDocument()
+      expect(screen.getByText('ロックあり（分散ロック）')).toBeInTheDocument()
+    })
+  })
+
+  it('shows timeline chart components after successful API call', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      const charts = screen.getAllByTestId('lock-timeline-chart')
+      expect(charts).toHaveLength(2)
+    })
+  })
+
+  it('displays error banner when API call fails', async () => {
+    mockRunDemo.mockRejectedValue(new Error('サーバーエラー'))
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラー')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show result panels on error', async () => {
+    mockRunDemo.mockRejectedValue(new Error('サーバーエラー'))
+    renderPage()
+    fireEvent.click(screen.getByText('デモを実行'))
+    await waitFor(() => {
+      expect(screen.queryByText('ロックなし（競合あり）')).not.toBeInTheDocument()
+      expect(screen.queryByText('ロックあり（分散ロック）')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not show result panels before button is clicked', () => {
+    renderPage()
+    expect(screen.queryByText('ロックなし（競合あり）')).not.toBeInTheDocument()
+    expect(screen.queryByText('ロックあり（分散ロック）')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/pages/LockMonitorPage.test.tsx
+++ b/frontend/src/test/pages/LockMonitorPage.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { LockMonitorPage } from '../../pages/LockMonitorPage'
+
+// Mock child components to avoid deep rendering
+vi.mock('../../components/locks/LockStatusChecker', () => ({
+  LockStatusChecker: () => <div data-testid="lock-status-checker" />,
+}))
+
+vi.mock('../../components/locks/LockOperationPanel', () => ({
+  LockOperationPanel: () => <div data-testid="lock-operation-panel" />,
+}))
+
+vi.mock('../../components/locks/LockMetricsTable', () => ({
+  LockMetricsTable: () => <div data-testid="lock-metrics-table" />,
+}))
+
+function renderPage(initialPath = '/locks') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/locks" element={<LockMonitorPage />} />
+        <Route path="/locks/demo" element={<div>lock-demo-page</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('LockMonitorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(screen.getByText('ロックモニター')).toBeInTheDocument()
+  })
+
+  it('renders LockStatusChecker component', () => {
+    renderPage()
+    expect(screen.getByTestId('lock-status-checker')).toBeInTheDocument()
+  })
+
+  it('renders LockOperationPanel component', () => {
+    renderPage()
+    expect(screen.getByTestId('lock-operation-panel')).toBeInTheDocument()
+  })
+
+  it('renders LockMetricsTable component', () => {
+    renderPage()
+    expect(screen.getByTestId('lock-metrics-table')).toBeInTheDocument()
+  })
+
+  it('renders navigation button "分散ロックデモ"', () => {
+    renderPage()
+    expect(screen.getByText('分散ロックデモ')).toBeInTheDocument()
+  })
+
+  it('navigates to /locks/demo when button is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByText('分散ロックデモ'))
+    expect(screen.getByText('lock-demo-page')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/pages/MetricsPage.test.tsx
+++ b/frontend/src/test/pages/MetricsPage.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { MetricsPage } from '../../pages/MetricsPage'
+
+// Mock APIs (usePolling calls these internally, but we mock usePolling directly)
+vi.mock('../../api/cache', () => ({
+  cacheApi: {
+    metrics: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/locks', () => ({
+  locksApi: {
+    metrics: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/health', () => ({
+  healthApi: {
+    get: vi.fn(),
+  },
+}))
+
+// Mock usePolling so we control returned data without running timers
+const mockRefetchCache = vi.fn()
+const mockRefetchLocks = vi.fn()
+const mockRefetchHealth = vi.fn()
+
+vi.mock('../../hooks/usePolling', () => ({
+  usePolling: vi.fn(),
+}))
+
+// Mock child panel components
+vi.mock('../../components/metrics/CacheMetricsPanel', () => ({
+  CacheMetricsPanel: () => <div data-testid="cache-metrics-panel" />,
+}))
+
+vi.mock('../../components/metrics/LockMetricsPanel', () => ({
+  LockMetricsPanel: () => <div data-testid="lock-metrics-panel" />,
+}))
+
+vi.mock('../../components/metrics/CircuitBreakerTable', () => ({
+  CircuitBreakerTable: () => <div data-testid="circuit-breaker-table" />,
+}))
+
+import { usePolling } from '../../hooks/usePolling'
+
+const mockUsePolling = vi.mocked(usePolling)
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MetricsPage />
+    </MemoryRouter>
+  )
+}
+
+describe('MetricsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // usePolling is called 3 times in sequence; return different refetch fns per call
+    let callCount = 0
+    mockUsePolling.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return { data: null, isLoading: false, error: null, refetch: mockRefetchCache }
+      }
+      if (callCount === 2) {
+        return { data: null, isLoading: false, error: null, refetch: mockRefetchLocks }
+      }
+      return { data: null, isLoading: false, error: null, refetch: mockRefetchHealth }
+    })
+  })
+
+  it('renders page heading "メトリクス"', () => {
+    renderPage()
+    expect(screen.getByText('メトリクス')).toBeInTheDocument()
+  })
+
+  it('renders CacheMetricsPanel', () => {
+    renderPage()
+    expect(screen.getByTestId('cache-metrics-panel')).toBeInTheDocument()
+  })
+
+  it('renders LockMetricsPanel', () => {
+    renderPage()
+    expect(screen.getByTestId('lock-metrics-panel')).toBeInTheDocument()
+  })
+
+  it('renders CircuitBreakerTable', () => {
+    renderPage()
+    expect(screen.getByTestId('circuit-breaker-table')).toBeInTheDocument()
+  })
+
+  it('renders refresh button', () => {
+    renderPage()
+    expect(screen.getByText('更新')).toBeInTheDocument()
+  })
+
+  it('renders CSV export button', () => {
+    renderPage()
+    expect(screen.getByText('CSV出力')).toBeInTheDocument()
+  })
+
+  it('calls all three refetch functions when refresh button is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByText('更新'))
+    expect(mockRefetchCache).toHaveBeenCalledTimes(1)
+    expect(mockRefetchLocks).toHaveBeenCalledTimes(1)
+    expect(mockRefetchHealth).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls usePolling three times with 15000ms interval', () => {
+    renderPage()
+    expect(mockUsePolling).toHaveBeenCalledTimes(3)
+    for (const call of mockUsePolling.mock.calls) {
+      expect((call[0] as { interval: number }).interval).toBe(15000)
+    }
+  })
+})

--- a/frontend/src/test/pages/RateLimiterPage.test.tsx
+++ b/frontend/src/test/pages/RateLimiterPage.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RateLimiterPage } from '../../pages/RateLimiterPage'
+
+// Mock hooks
+vi.mock('../../hooks/usePolling', () => ({
+  usePolling: vi.fn(),
+}))
+
+// Mock API
+vi.mock('../../api/rateLimiter', () => ({
+  rateLimiterApi: {
+    getStatus: vi.fn(),
+    flood: vi.fn(),
+  },
+}))
+
+// Mock sub-component
+vi.mock('../../components/metrics/TokenBucketAnimation', () => ({
+  TokenBucketAnimation: ({ availablePermissions, maxPermissions, waitingThreads }: {
+    availablePermissions: number
+    maxPermissions: number
+    waitingThreads: number
+  }) => (
+    <div
+      data-testid="token-bucket-animation"
+      data-available={availablePermissions}
+      data-max={maxPermissions}
+      data-waiting={waitingThreads}
+    />
+  ),
+}))
+
+import { usePolling } from '../../hooks/usePolling'
+import { rateLimiterApi } from '../../api/rateLimiter'
+
+const mockUsePolling = vi.mocked(usePolling)
+const mockFlood = vi.mocked(rateLimiterApi.flood)
+
+const mockStatus = {
+  limitForPeriod: 10,
+  availablePermissions: 8,
+  numberOfWaitingThreads: 0,
+  cyclePeriodMs: 1000,
+}
+
+const mockFloodResult = {
+  requested: 15,
+  permitted: 10,
+  rejected: 5,
+  events: [
+    { workerId: 1, permitted: true, relativeMs: 0 },
+    { workerId: 2, permitted: false, relativeMs: 5 },
+  ],
+  timestamp: '2026-04-04T00:00:00Z',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RateLimiterPage />
+    </MemoryRouter>
+  )
+}
+
+describe('RateLimiterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePolling.mockReturnValue({
+      data: mockStatus,
+      error: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockFlood.mockResolvedValue(mockFloodResult)
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(screen.getByText('Rate Limiter バケツアニメーション')).toBeInTheDocument()
+  })
+
+  it('renders TokenBucketAnimation component', () => {
+    renderPage()
+    expect(screen.getByTestId('token-bucket-animation')).toBeInTheDocument()
+  })
+
+  it('shows default total of 15 (workers=5 * burstCount=3)', () => {
+    renderPage()
+    // The page renders "合計リクエスト数: {workers * burstCount}" = 5 * 3 = 15
+    expect(screen.getByText('15')).toBeInTheDocument()
+  })
+
+  it('renders flood button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /フラッド実行/ })).toBeInTheDocument()
+  })
+
+  it('flood button calls rateLimiterApi.flood with default workers and burstCount', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(mockFlood).toHaveBeenCalledWith(5, 3)
+    })
+  })
+
+  it('displays flood results after successful call', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('実行結果')).toBeInTheDocument()
+    })
+    // Section labels appear in the result grid
+    expect(screen.getByText('総リクエスト')).toBeInTheDocument()
+    expect(screen.getByText('許可')).toBeInTheDocument()
+    expect(screen.getByText('拒否')).toBeInTheDocument()
+  })
+
+  it('displays error message when flood fails', async () => {
+    mockFlood.mockRejectedValue(new Error('レート制限エラー'))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('レート制限エラー')).toBeInTheDocument()
+    })
+  })
+
+  it('shows 実行中... while flood is in progress', async () => {
+    // Return a promise that never resolves to keep loading state
+    mockFlood.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('実行中...')).toBeInTheDocument()
+    })
+  })
+
+  it('updates total when workers slider changes', async () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    // First slider is workers (default 5), second is burstCount (default 3)
+    fireEvent.change(sliders[0], { target: { value: '10' } })
+    await waitFor(() => {
+      // 10 * 3 = 30
+      expect(screen.getByText('30')).toBeInTheDocument()
+    })
+  })
+
+  it('updates total when burstCount slider changes', async () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[1], { target: { value: '5' } })
+    await waitFor(() => {
+      // 5 * 5 = 25
+      expect(screen.getByText('25')).toBeInTheDocument()
+    })
+  })
+
+  it('calls flood with updated slider values', async () => {
+    renderPage()
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[0], { target: { value: '8' } })
+    fireEvent.change(sliders[1], { target: { value: '4' } })
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(mockFlood).toHaveBeenCalledWith(8, 4)
+    })
+  })
+
+  it('shows status values from polling when available', () => {
+    renderPage()
+    // cyclePeriodMs from mockStatus = 1000
+    expect(screen.getByText('1000ms')).toBeInTheDocument()
+    // maxPermissions = limitForPeriod = 10
+    const maxPermissionsEls = screen.getAllByText('10')
+    expect(maxPermissionsEls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows fallback values when status is not yet loaded', () => {
+    mockUsePolling.mockReturnValue({
+      data: null,
+      error: null,
+      isLoading: true,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    // When status is null, maxPermissions defaults to 10 and cyclePeriodMs shows '-'
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('renders event log entries after flood result', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /フラッド実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('実行結果')).toBeInTheDocument()
+    })
+    // Event log shows worker IDs
+    expect(screen.getByText('W1')).toBeInTheDocument()
+    expect(screen.getByText('W2')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/pages/RedisCliPage.test.tsx
+++ b/frontend/src/test/pages/RedisCliPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RedisCliPage } from '../../pages/RedisCliPage'
+
+// Mock the RedisCli component to avoid deep rendering
+vi.mock('../../components/cli/RedisCli', () => ({
+  RedisCli: () => <div data-testid="redis-cli" />,
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RedisCliPage />
+    </MemoryRouter>
+  )
+}
+
+describe('RedisCliPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page heading "Redis CLI"', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: 'Redis CLI' })).toBeInTheDocument()
+  })
+
+  it('renders description text', () => {
+    renderPage()
+    expect(
+      screen.getByText('ブラウザ内から Redis コマンドを実行できます（ホワイトリスト制限あり）')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the RedisCli component', () => {
+    renderPage()
+    expect(screen.getByTestId('redis-cli')).toBeInTheDocument()
+  })
+
+  it('renders command reference section heading', () => {
+    renderPage()
+    expect(screen.getByText('使用可能コマンド')).toBeInTheDocument()
+  })
+
+  it('shows GET <key> command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('GET <key>')).toBeInTheDocument()
+  })
+
+  it('shows SET <key> <value> command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('SET <key> <value>')).toBeInTheDocument()
+  })
+
+  it('shows KEYS <pattern> command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('KEYS <pattern>')).toBeInTheDocument()
+  })
+
+  it('shows INFO command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('INFO')).toBeInTheDocument()
+  })
+
+  it('shows HGETALL <key> command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('HGETALL <key>')).toBeInTheDocument()
+  })
+
+  it('shows SLOWLOG GET command in the reference list', () => {
+    renderPage()
+    expect(screen.getByText('SLOWLOG GET')).toBeInTheDocument()
+  })
+
+  it('renders all 16 command entries', () => {
+    renderPage()
+    // Each command has a description alongside it; count the description elements.
+    // Spot-check: all 16 commands produce 16 .font-mono elements in the reference list.
+    // We can verify by counting green mono spans (one per command).
+    const commandTexts = [
+      'GET <key>',
+      'SET <key> <value>',
+      'KEYS <pattern>',
+      'SCAN 0',
+      'TTL <key>',
+      'PTTL <key>',
+      'TYPE <key>',
+      'STRLEN <key>',
+      'LLEN <key>',
+      'HGETALL <key>',
+      'SMEMBERS <key>',
+      'ZRANGE <key> 0 -1',
+      'ZCARD <key>',
+      'INFO',
+      'MEMORY USAGE <key>',
+      'SLOWLOG GET',
+    ]
+    for (const cmd of commandTexts) {
+      expect(screen.getByText(cmd)).toBeInTheDocument()
+    }
+  })
+
+  it('shows Tab keyboard hint', () => {
+    renderPage()
+    expect(screen.getByText('Tab: コマンド補完')).toBeInTheDocument()
+  })
+
+  it('shows arrow key keyboard hint for command history', () => {
+    renderPage()
+    expect(screen.getByText('↑/↓: コマンド履歴')).toBeInTheDocument()
+  })
+
+  it('shows Enter keyboard hint', () => {
+    renderPage()
+    expect(screen.getByText('Enter: 実行')).toBeInTheDocument()
+  })
+
+  it('shows a description for GET <key>', () => {
+    renderPage()
+    expect(screen.getByText('String 値を取得')).toBeInTheDocument()
+  })
+
+  it('shows a description for HGETALL <key>', () => {
+    renderPage()
+    expect(screen.getByText('ハッシュ全取得')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/pages/RedisVisualizerPage.test.tsx
+++ b/frontend/src/test/pages/RedisVisualizerPage.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RedisVisualizerPage } from '../../pages/RedisVisualizerPage'
+
+// Mock cacheApi — child sub-components are all defined in the same file, so we do NOT mock them
+vi.mock('../../api/cache', () => ({
+  cacheApi: {
+    searchKeys: vi.fn(),
+    batchGet: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { cacheApi } from '../../api/cache'
+
+const mockSearchKeys = vi.mocked(cacheApi.searchKeys)
+const mockBatchGet = vi.mocked(cacheApi.batchGet)
+const mockDelete = vi.mocked(cacheApi.delete)
+
+// Default: return a set of STRING keys
+const defaultSearchResult = {
+  pattern: '*',
+  limit: 200,
+  count: 3,
+  keys: ['cache:user:1', 'cache:user:2', 'session:abc'],
+}
+
+const defaultBatchGetResult = {
+  results: {
+    'cache:user:1': 'Alice',
+    'cache:user:2': 'Bob',
+    'session:abc': '{"token":"xyz"}',
+  },
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RedisVisualizerPage />
+    </MemoryRouter>
+  )
+}
+
+describe('RedisVisualizerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchKeys.mockResolvedValue(defaultSearchResult)
+    mockBatchGet.mockResolvedValue(defaultBatchGetResult)
+    mockDelete.mockResolvedValue({ key: '', deleted: true })
+  })
+
+  it('renders REDIS label in toolbar', async () => {
+    renderPage()
+    // The toolbar shows "REDIS" in red
+    expect(screen.getByText('REDIS')).toBeInTheDocument()
+  })
+
+  it('renders Visual Explorer label in toolbar', async () => {
+    renderPage()
+    expect(screen.getByText('Visual Explorer')).toBeInTheDocument()
+  })
+
+  it('pattern input has default value "*"', () => {
+    renderPage()
+    const patternInput = screen.getByPlaceholderText('pattern: *')
+    expect(patternInput).toHaveValue('*')
+  })
+
+  it('renders SCAN button after initial load', async () => {
+    renderPage()
+    // During initial load the button shows '...' — wait for it to become 'SCAN'
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'SCAN' })).toBeInTheDocument()
+    })
+  })
+
+  it('calls searchKeys and batchGet on initial mount', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(mockSearchKeys).toHaveBeenCalledTimes(1)
+      expect(mockBatchGet).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('displays loaded keys in the key list', async () => {
+    renderPage()
+    await waitFor(() => {
+      // Keys can appear more than once (key list + auto-selected detail panel header)
+      expect(screen.getAllByText('cache:user:1').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('cache:user:2').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('session:abc').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('calls searchKeys with the pattern from input on SCAN click', async () => {
+    renderPage()
+    // Wait for initial load to complete
+    await waitFor(() => expect(mockSearchKeys).toHaveBeenCalledTimes(1))
+
+    const patternInput = screen.getByPlaceholderText('pattern: *')
+    fireEvent.change(patternInput, { target: { value: 'cache:*' } })
+    fireEvent.click(screen.getByRole('button', { name: 'SCAN' }))
+
+    await waitFor(() => {
+      expect(mockSearchKeys).toHaveBeenCalledWith('cache:*', 200)
+    })
+  })
+
+  it('shows "キーなし" message when no keys are returned', async () => {
+    mockSearchKeys.mockResolvedValue({ pattern: '*', limit: 200, count: 0, keys: [] })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/キーなし/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows total key count in footer', async () => {
+    renderPage()
+    await waitFor(() => {
+      // Footer shows "Total keys" label
+      expect(screen.getByText('Total keys')).toBeInTheDocument()
+      // 3 keys loaded; the count "3" appears at least once (footer + possibly other places)
+      expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('shows detail panel when a key is clicked', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('cache:user:1').length).toBeGreaterThanOrEqual(1)
+    })
+    // Click the key in the sidebar list (first occurrence)
+    fireEvent.click(screen.getAllByText('cache:user:1')[0])
+    await waitFor(() => {
+      // The detail panel header shows STRING type badge (since 'Alice' is a plain string)
+      // STRING also appears in the right-panel DATA STRUCTURES list, so use getAllByText
+      expect(screen.getAllByText('STRING').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('calls cacheApi.delete when × button is clicked for a key', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByTitle('削除').length).toBeGreaterThanOrEqual(1)
+    })
+    // Each key row has a × delete button; click the first one
+    const deleteButtons = screen.getAllByTitle('削除')
+    fireEvent.click(deleteButtons[0])
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('removes deleted key from the list', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByTitle('削除').length).toBe(3)
+    })
+    const deleteButtons = screen.getAllByTitle('削除')
+    fireEvent.click(deleteButtons[0])
+    await waitFor(() => {
+      // One key should have been removed — only 2 delete buttons remain
+      expect(screen.getAllByTitle('削除').length).toBe(2)
+    })
+  })
+
+  it('shows ALL filter button with count', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('ALL (3)')).toBeInTheDocument()
+    })
+  })
+
+  it('shows DATA STRUCTURES panel', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('DATA STRUCTURES')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when searchKeys fails', async () => {
+    mockSearchKeys.mockRejectedValue(new Error('Redis 接続エラー'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/Redis 接続エラー/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows scanning indicator while loading', async () => {
+    // Use a never-resolving promise so loading state persists
+    mockSearchKeys.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Scanning...')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "スキャン中..." in detail panel placeholder while loading', async () => {
+    mockSearchKeys.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('スキャン中...')).toBeInTheDocument()
+    })
+  })
+
+  it('key filter input filters the displayed keys', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('cache:user:1').length).toBeGreaterThanOrEqual(1)
+    })
+    const filterInput = screen.getByPlaceholderText(/key filter/)
+    fireEvent.change(filterInput, { target: { value: 'session' } })
+    await waitFor(() => {
+      // cache:user:1 should no longer appear in the key list
+      // (it may still appear in the detail panel, so check it's gone from key list)
+      const allByUser1 = screen.queryAllByText('cache:user:1')
+      // After filtering to 'session', cache:user:1 should not be in the filtered sidebar list
+      // The detail panel still shows the auto-selected key so we check count is minimal
+      expect(allByUser1.length).toBeLessThanOrEqual(1)
+      expect(screen.getAllByText('session:abc').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('shows "フィルター結果なし" when filter matches nothing', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByTitle('削除').length).toBeGreaterThanOrEqual(1)
+    })
+    const filterInput = screen.getByPlaceholderText(/key filter/)
+    fireEvent.change(filterInput, { target: { value: 'nonexistent-key-xyz' } })
+    await waitFor(() => {
+      expect(screen.getByText('フィルター結果なし')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Memory estimate in footer', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Memory (est.)')).toBeInTheDocument()
+    })
+  })
+
+  it('SCAN button submits the form when pattern is entered', async () => {
+    renderPage()
+    await waitFor(() => expect(mockSearchKeys).toHaveBeenCalledTimes(1))
+
+    const patternInput = screen.getByPlaceholderText('pattern: *')
+    fireEvent.change(patternInput, { target: { value: 'session:*' } })
+
+    // Submit via Enter key on the form
+    fireEvent.submit(patternInput.closest('form')!)
+    await waitFor(() => {
+      expect(mockSearchKeys).toHaveBeenCalledWith('session:*', 200)
+    })
+  })
+})

--- a/frontend/src/test/pages/SagaTracerPage.test.tsx
+++ b/frontend/src/test/pages/SagaTracerPage.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { SagaTracerPage } from '../../pages/SagaTracerPage'
+
+// Mock API
+vi.mock('../../api/transaction', () => ({
+  transactionApi: {
+    runSaga: vi.fn(),
+    runSagaFail: vi.fn(),
+  },
+}))
+
+// Mock sub-component
+vi.mock('../../components/locks/SagaFlowDiagram', () => ({
+  SagaFlowDiagram: ({ steps, compensationSteps }: {
+    steps: unknown[]
+    compensationSteps?: unknown[]
+  }) => (
+    <div
+      data-testid="saga-flow-diagram"
+      data-steps={steps.length}
+      data-compensation={compensationSteps?.length ?? 0}
+    />
+  ),
+}))
+
+import { transactionApi } from '../../api/transaction'
+
+const mockRunSaga = vi.mocked(transactionApi.runSaga)
+const mockRunSagaFail = vi.mocked(transactionApi.runSagaFail)
+
+const mockSuccessResult = {
+  steps: [
+    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12 },
+    { name: 'PaymentProcessed', status: 'SUCCESS' as const, durationMs: 34 },
+    { name: 'InventoryReserved', status: 'SUCCESS' as const, durationMs: 8 },
+  ],
+  overallStatus: 'SUCCESS' as const,
+  timestamp: '2026-04-04T00:00:00Z',
+}
+
+const mockFailResult = {
+  steps: [
+    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12 },
+    { name: 'PaymentProcessed', status: 'FAILED' as const, durationMs: 5 },
+  ],
+  compensationSteps: [
+    { name: 'OrderCancelled', status: 'COMPENSATED' as const, durationMs: 9 },
+  ],
+  overallStatus: 'COMPENSATED' as const,
+  timestamp: '2026-04-04T00:00:00Z',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SagaTracerPage />
+    </MemoryRouter>
+  )
+}
+
+describe('SagaTracerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunSaga.mockResolvedValue(mockSuccessResult)
+    mockRunSagaFail.mockResolvedValue(mockFailResult)
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(screen.getByText('Saga パターン実行トレーサー')).toBeInTheDocument()
+  })
+
+  it('renders 通常実行 button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /通常実行/ })).toBeInTheDocument()
+  })
+
+  it('renders 失敗 → 補償実行 button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /失敗.*補償実行/ })).toBeInTheDocument()
+  })
+
+  it('does not show result section initially', () => {
+    renderPage()
+    expect(screen.queryByTestId('saga-flow-diagram')).not.toBeInTheDocument()
+    expect(screen.queryByText('SUCCESS')).not.toBeInTheDocument()
+  })
+
+  it('calls transactionApi.runSaga when 通常実行 is clicked', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(mockRunSaga).toHaveBeenCalledTimes(1)
+    })
+    expect(mockRunSagaFail).not.toHaveBeenCalled()
+  })
+
+  it('calls transactionApi.runSagaFail when 失敗 → 補償実行 is clicked', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /失敗.*補償実行/ }))
+    await waitFor(() => {
+      expect(mockRunSagaFail).toHaveBeenCalledTimes(1)
+    })
+    expect(mockRunSaga).not.toHaveBeenCalled()
+  })
+
+  it('shows 実行中... while request is in progress', async () => {
+    mockRunSaga.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('実行中...')).toBeInTheDocument()
+    })
+  })
+
+  it('disables buttons while loading', async () => {
+    mockRunSaga.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /通常実行/ })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /失敗.*補償実行/ })).toBeDisabled()
+    })
+  })
+
+  it('shows SUCCESS overallStatus badge after normal run', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('SUCCESS')).toBeInTheDocument()
+    })
+  })
+
+  it('shows COMPENSATED overallStatus badge after fail run', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /失敗.*補償実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('COMPENSATED')).toBeInTheDocument()
+    })
+  })
+
+  it('renders SagaFlowDiagram after successful run', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByTestId('saga-flow-diagram')).toBeInTheDocument()
+    })
+  })
+
+  it('passes correct step count to SagaFlowDiagram', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      const diagram = screen.getByTestId('saga-flow-diagram')
+      expect(diagram).toHaveAttribute('data-steps', '3')
+    })
+  })
+
+  it('passes compensation steps to SagaFlowDiagram after fail run', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /失敗.*補償実行/ }))
+    await waitFor(() => {
+      const diagram = screen.getByTestId('saga-flow-diagram')
+      expect(diagram).toHaveAttribute('data-compensation', '1')
+    })
+  })
+
+  it('displays error message when runSaga fails', async () => {
+    mockRunSaga.mockRejectedValue(new Error('サーバーエラーが発生しました'))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラーが発生しました')).toBeInTheDocument()
+    })
+  })
+
+  it('displays error message when runSagaFail throws', async () => {
+    mockRunSagaFail.mockRejectedValue(new Error('接続タイムアウト'))
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /失敗.*補償実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('接続タイムアウト')).toBeInTheDocument()
+    })
+  })
+
+  it('clears previous result when a new run starts', async () => {
+    renderPage()
+    // First run completes with SUCCESS
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('SUCCESS')).toBeInTheDocument()
+    })
+    // Second run — keep it pending so result is cleared
+    mockRunSagaFail.mockReturnValue(new Promise(() => {}))
+    fireEvent.click(screen.getByRole('button', { name: /失敗.*補償実行/ }))
+    await waitFor(() => {
+      expect(screen.queryByText('SUCCESS')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows explanation section about Saga pattern after result', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('Saga パターンとは')).toBeInTheDocument()
+    })
+  })
+
+  it('shows legend section after result', async () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: /通常実行/ }))
+    await waitFor(() => {
+      expect(screen.getByText('凡例')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/test/pages/TransferPage.test.tsx
+++ b/frontend/src/test/pages/TransferPage.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { TransferPage } from '../../pages/TransferPage'
+import type { TransferResponse } from '../../types/locks'
+
+// Mock child components
+vi.mock('../../components/locks/TransferForm', () => ({
+  TransferForm: ({
+    onTransferComplete,
+    onError,
+  }: {
+    onTransferComplete: (r: TransferResponse) => void
+    onError: (msg: string) => void
+  }) => (
+    <div data-testid="transfer-form">
+      <button
+        onClick={() =>
+          onTransferComplete({
+            transferId: 'txn-1',
+            success: true,
+            fromKey: 'account:alice',
+            toKey: 'account:bob',
+            amount: 5000,
+            timestamp: Date.now(),
+          })
+        }
+      >
+        trigger-complete
+      </button>
+      <button onClick={() => onError('送金に失敗しました')}>trigger-error</button>
+    </div>
+  ),
+}))
+
+vi.mock('../../components/locks/TransferLog', () => ({
+  TransferLog: ({ logs }: { logs: TransferResponse[] }) => (
+    <div data-testid="transfer-log">
+      <span data-testid="log-count">{logs.length}</span>
+    </div>
+  ),
+}))
+
+vi.mock('../../components/common/ToastContainer', () => ({
+  ToastContainer: ({
+    toasts,
+  }: {
+    toasts: { id: string; message: string; variant: string }[]
+  }) => (
+    <div data-testid="toast-container">
+      {toasts.map(t => (
+        <div key={t.id} data-testid={`toast-${t.variant}`}>
+          {t.message}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/locks/transfer']}>
+      <Routes>
+        <Route path="/locks/transfer" element={<TransferPage />} />
+        <Route path="/locks" element={<div>lock-monitor-page</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('TransferPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page heading', () => {
+    renderPage()
+    expect(
+      screen.getByText('送金デモ（分散ロック + トランザクション）')
+    ).toBeInTheDocument()
+  })
+
+  it('renders back button labeled "ロックモニター"', () => {
+    renderPage()
+    expect(screen.getByText('ロックモニター')).toBeInTheDocument()
+  })
+
+  it('navigates to /locks when back button is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByText('ロックモニター'))
+    expect(screen.getByText('lock-monitor-page')).toBeInTheDocument()
+  })
+
+  it('renders TransferForm component', () => {
+    renderPage()
+    expect(screen.getByTestId('transfer-form')).toBeInTheDocument()
+  })
+
+  it('renders TransferLog component', () => {
+    renderPage()
+    expect(screen.getByTestId('transfer-log')).toBeInTheDocument()
+  })
+
+  it('renders ToastContainer component', () => {
+    renderPage()
+    expect(screen.getByTestId('toast-container')).toBeInTheDocument()
+  })
+
+  it('adds log entry when transfer completes successfully', async () => {
+    renderPage()
+    expect(screen.getByTestId('log-count')).toHaveTextContent('0')
+    fireEvent.click(screen.getByText('trigger-complete'))
+    await waitFor(() => {
+      expect(screen.getByTestId('log-count')).toHaveTextContent('1')
+    })
+  })
+
+  it('shows success toast when transfer completes', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('trigger-complete'))
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-success')).toBeInTheDocument()
+      expect(screen.getByTestId('toast-success').textContent).toMatch(/5,000/)
+    })
+  })
+
+  it('shows error toast when error callback is triggered', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('trigger-error'))
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-error')).toBeInTheDocument()
+      expect(screen.getByTestId('toast-error')).toHaveTextContent('送金に失敗しました')
+    })
+  })
+
+  it('does not add log entry on error', async () => {
+    renderPage()
+    fireEvent.click(screen.getByText('trigger-error'))
+    await waitFor(() => {
+      expect(screen.getByTestId('log-count')).toHaveTextContent('0')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 9ページ分のテストファイル新規作成（127テスト追加、計259テスト通過）
- 対象: LockMonitorPage, TransferPage, LockDemoPage, MetricsPage, CircuitBreakerPage, RateLimiterPage, SagaTracerPage, RedisCliPage, RedisVisualizerPage
- 既存テストパターン踏襲（vi.mock + MemoryRouter + waitFor）

## Test plan
- [ ] `cd frontend && npm test` で全259テスト通過
- [ ] `cd frontend && npm test -- --coverage` でカバレッジ閾値（lines 90%）達成

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)