### PR TITLE
fix: フロントエンドアクセシビリティ改善

### DIFF
--- a/frontend/src/components/cache/AddKeyModal.tsx
+++ b/frontend/src/components/cache/AddKeyModal.tsx
@@ -55,10 +55,10 @@ export function AddKeyModal({ isOpen, onClose, onAdd }: AddKeyModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" role="dialog" aria-modal="true" aria-labelledby="addkey-dialog-title">
       <div className="bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-white font-semibold">新規キー追加</h3>
+          <h3 id="addkey-dialog-title" className="text-white font-semibold">新規キー追加</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-white">
             <X className="h-5 w-5" />
           </button>
@@ -66,8 +66,9 @@ export function AddKeyModal({ isOpen, onClose, onAdd }: AddKeyModalProps) {
 
         <div className="space-y-3">
           <div>
-            <label className="block text-xs text-gray-400 mb-1">キー</label>
+            <label htmlFor="addkey-key" className="block text-xs text-gray-400 mb-1">キー</label>
             <input
+              id="addkey-key"
               type="text"
               value={key}
               onChange={(e) => setKey(e.target.value)}
@@ -77,8 +78,9 @@ export function AddKeyModal({ isOpen, onClose, onAdd }: AddKeyModalProps) {
           </div>
 
           <div>
-            <label className="block text-xs text-gray-400 mb-1">値</label>
+            <label htmlFor="addkey-value" className="block text-xs text-gray-400 mb-1">値</label>
             <textarea
+              id="addkey-value"
               value={rawValue}
               onChange={(e) => setRawValue(e.target.value)}
               placeholder='{"userId": 1042, "name": "asdf"}'
@@ -88,8 +90,9 @@ export function AddKeyModal({ isOpen, onClose, onAdd }: AddKeyModalProps) {
           </div>
 
           <div>
-            <label className="block text-xs text-gray-400 mb-1">TTL（秒）</label>
+            <label htmlFor="addkey-ttl" className="block text-xs text-gray-400 mb-1">TTL（秒）</label>
             <input
+              id="addkey-ttl"
               type="number"
               value={ttl}
               onChange={(e) => setTtl(e.target.value)}

--- a/frontend/src/components/common/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/common/DeleteConfirmDialog.tsx
@@ -9,9 +9,9 @@ interface Props {
 export function DeleteConfirmDialog({ isOpen, target, onConfirm, onCancel, isDeleting }: Props) {
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" role="dialog" aria-modal="true" aria-labelledby="delete-dialog-title">
       <div className="bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4">
-        <h3 className="text-white font-semibold mb-2">削除の確認</h3>
+        <h3 id="delete-dialog-title" className="text-white font-semibold mb-2">削除の確認</h3>
         <p className="text-gray-300 text-sm mb-4">
           <code className="bg-gray-700 px-1 rounded">{target}</code> を削除します。この操作は取り消せません。
         </p>

--- a/frontend/src/components/common/ToastContainer.tsx
+++ b/frontend/src/components/common/ToastContainer.tsx
@@ -11,7 +11,7 @@ interface Props { toasts: ToastItem[] }
 
 export function ToastContainer({ toasts }: Props) {
   return (
-    <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
+    <div role="status" aria-live="polite" className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
       {toasts.map(t => (
         <div
           key={t.id}

--- a/frontend/src/components/dashboard/StatusCard.tsx
+++ b/frontend/src/components/dashboard/StatusCard.tsx
@@ -22,6 +22,13 @@ const dotColors: Record<string, string> = {
   neutral: 'bg-gray-400',
 };
 
+const dotLabels: Record<string, string> = {
+  ok: '正常',
+  warn: '警告',
+  error: 'エラー',
+  neutral: '不明',
+};
+
 export function StatusCard({ label, value, status = 'neutral', icon, onClick }: StatusCardProps) {
   return (
     <button
@@ -32,7 +39,7 @@ export function StatusCard({ label, value, status = 'neutral', icon, onClick }: 
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs text-gray-400 uppercase tracking-wide">{label}</span>
         <div className="flex items-center gap-2">
-          <span className={`inline-block h-2 w-2 rounded-full ${dotColors[status]}`} />
+          <span className={`inline-block h-2 w-2 rounded-full ${dotColors[status]}`} aria-label={dotLabels[status]} />
           {icon && <span className="text-gray-400">{icon}</span>}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- モーダルに role="dialog", aria-modal, aria-labelledby 追加（DeleteConfirmDialog, AddKeyModal）
- AddKeyModal のフォームラベルに htmlFor/id 紐付け追加
- ToastContainer に role="status", aria-live="polite" 追加
- StatusCard のステータスドットに aria-label 追加

## Test plan
- [ ] `cd frontend && npm test` で全テスト通過
- [ ] Chrome DevTools Accessibility パネルでモーダルの role="dialog" 確認
- [ ] スクリーンリーダーでトースト通知が読み上げられること確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)