### PR TITLE
test: SecurityConfig 統合テスト追加 (#19)

### DIFF
--- a/backend/src/test/java/com/example/cache/config/SecurityConfigDevModeIT.java
+++ b/backend/src/test/java/com/example/cache/config/SecurityConfigDevModeIT.java
@@ -1,0 +1,55 @@
+package com.example.cache.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("test")
+class SecurityConfigDevModeIT {
+
+    @Container
+    static GenericContainer<?> redis =
+            new GenericContainer<>("redis:alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry r) {
+        r.add("REDIS_HOST", redis::getHost);
+        r.add("REDIS_PORT", () -> redis.getMappedPort(6379).toString());
+        r.add("REDIS_PASSWORD", () -> "");
+        r.add("api.key", () -> "");
+        r.add("demo.features.enabled", () -> "true");
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void api_endpoint_accessible_without_auth_in_dev_mode() throws Exception {
+        mockMvc.perform(get("/api/cache/search").param("pattern", "*"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void admin_endpoint_accessible_without_auth_in_dev_mode() throws Exception {
+        mockMvc.perform(post("/api/cache/simulate-error")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enabled\": true}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/example/cache/config/SecurityConfigIT.java
+++ b/backend/src/test/java/com/example/cache/config/SecurityConfigIT.java
@@ -1,0 +1,100 @@
+package com.example.cache.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("test")
+class SecurityConfigIT {
+
+    private static final String TEST_API_KEY = "test-api-key-12345";
+
+    @Container
+    static GenericContainer<?> redis =
+            new GenericContainer<>("redis:alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry r) {
+        r.add("REDIS_HOST", redis::getHost);
+        r.add("REDIS_PORT", () -> redis.getMappedPort(6379).toString());
+        r.add("REDIS_PASSWORD", () -> "");
+        r.add("api.key", () -> TEST_API_KEY);
+        r.add("demo.features.enabled", () -> "true");
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+    // --- Public endpoints (no auth required) ---
+
+    @Test
+    void health_endpoint_accessible_without_auth() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk());
+    }
+
+    // --- Protected endpoints (require valid API key) ---
+
+    @Test
+    void api_endpoint_rejected_without_api_key() throws Exception {
+        mockMvc.perform(get("/api/cache/search").param("pattern", "*"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void api_endpoint_rejected_with_invalid_api_key() throws Exception {
+        mockMvc.perform(get("/api/cache/search")
+                        .param("pattern", "*")
+                        .header("X-API-Key", "wrong-key"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void api_endpoint_returns_200_with_valid_api_key() throws Exception {
+        mockMvc.perform(get("/api/cache/search")
+                        .param("pattern", "*")
+                        .header("X-API-Key", TEST_API_KEY))
+                .andExpect(status().isOk());
+    }
+
+    // --- DEMO_ADMIN endpoints ---
+
+    @Test
+    void admin_endpoint_accessible_with_valid_api_key() throws Exception {
+        mockMvc.perform(post("/api/cache/simulate-error")
+                        .header("X-API-Key", TEST_API_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enabled\": true}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void admin_endpoint_rejected_without_api_key() throws Exception {
+        mockMvc.perform(post("/api/cache/simulate-error")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enabled\": true}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void lock_release_admin_endpoint_rejected_without_api_key() throws Exception {
+        mockMvc.perform(post("/api/lock/release"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Summary
- `SecurityConfigIT`: API Key 認証の prod モードテスト（7ケース）
  - 公開エンドポイント（`/health`）→ 認証なしで 200
  - 保護エンドポイント → API Key なし/無効で 403、有効で 200
  - DEMO_ADMIN エンドポイント → API Key なしで 403、有効で 200
- `SecurityConfigDevModeIT`: dev モード（`api.key` 未設定）テスト（2ケー���）
  - 保護/DEMO_ADMIN エンドポイント → 認証なしで 200

## Test plan
- [x] `./gradlew test --tests "com.example.cache.config.SecurityConfig*IT"` — 9テスト全通過
- [x] `./gradlew test` — 全バックエンドテスト通過（リグレッションなし）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)