### PR TITLE
feat: OTel Loki ログパイプライン + memory_limiter 追加 (#20)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - "4318:4318"
     depends_on:
       - jaeger
+      - loki
 
   jaeger:
     image: jaegertracing/all-in-one:2.6
@@ -80,6 +81,15 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"
+
+  loki:
+    image: grafana/loki:3.4.2
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki-data:/loki
 
   prometheus:
     image: prom/prometheus:v3.4.0
@@ -110,8 +120,10 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+      - loki
 
 volumes:
   redis-data:
   prometheus-data:
   grafana-data:
+  loki-data:

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -7,3 +7,9 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/docker/otel-collector-config.yaml
+++ b/docker/otel-collector-config.yaml
@@ -10,6 +10,10 @@ processors:
   batch:
     timeout: 1s
     send_batch_size: 1024
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 256
+    spike_limit_mib: 64
 
 exporters:
   debug:
@@ -22,18 +26,20 @@ exporters:
     endpoint: http://prometheus:9090/api/v1/write
     tls:
       insecure: true
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug, otlp_grpc/jaeger]
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug, prometheusremotewrite]
     logs:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [debug]
+      processors: [memory_limiter, batch]
+      exporters: [debug, loki]


### PR DESCRIPTION
## Summary
- Loki サービスを `docker-compose.yml` に追加（`grafana/loki:3.4.2`）
- OTel Collector の logs パイプラインに `loki` エクスポーターを設定（`debug` のみ → `loki + debug`）
- 全パイプラインに `memory_limiter` プロセッサ追加（256 MiB上限、OOM防止）
- Grafana に Loki データソースを自動プロビジョニング

## Test plan
- [ ] `docker compose up -d` → 全サービス healthy
- [ ] `docker compose logs otel-collector` → エラーなし
- [ ] Grafana > Explore > Loki データソースでバックエンドログが表示さ��る
- [ ] `docker stats` で OTel Collector のメモリ使用量が安定

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)