### PR TITLE
P3 バックエンド改善: KEYS除外, Watchdog有効化, 補償Txタイムアウト (#27)

### DIFF
--- a/backend/src/main/java/com/example/cache/controller/CliController.java
+++ b/backend/src/main/java/com/example/cache/controller/CliController.java
@@ -28,7 +28,7 @@ public class CliController {
 
     /** 読み取り専用コマンド（常に許可） */
     private static final Set<String> ALLOWED_COMMANDS = Set.of(
-            "GET", "SET", "KEYS", "SCAN", "TTL", "PTTL", "TYPE",
+            "GET", "SET", "SCAN", "TTL", "PTTL", "TYPE",
             "INFO", "LLEN", "HGETALL", "SMEMBERS", "ZRANGE", "ZCARD",
             "STRLEN", "MEMORY", "SLOWLOG"
     );
@@ -117,14 +117,6 @@ public class CliController {
                 String setValue = String.join(" ", java.util.Arrays.copyOfRange(parts, 2, parts.length));
                 redissonClient.<String>getBucket(parts[1]).set(setValue);
                 yield "OK";
-            }
-            case "KEYS" -> {
-                String pattern = parts.length > 1 ? parts[1] : "*";
-                var keys = new java.util.ArrayList<String>();
-                redissonClient.getKeys().getKeysStream(
-                    new org.redisson.api.options.KeysScanParams().pattern(pattern).limit(100)
-                ).forEach(keys::add);
-                yield keys;
             }
             case "TTL" -> {
                 if (parts.length < 2) yield "ERR: TTL requires a key";

--- a/backend/src/main/java/com/example/cache/service/DistributedLockService.java
+++ b/backend/src/main/java/com/example/cache/service/DistributedLockService.java
@@ -73,7 +73,7 @@ public class DistributedLockService {
 
     // ロック設定定数
     private static final int DEFAULT_WAIT_TIME_SECONDS = 10; // デフォルト待機時間
-    private static final int DEFAULT_LEASE_TIME_SECONDS = 30; // デフォルトリース時間（-1で自動更新）
+    private static final int DEFAULT_LEASE_TIME_SECONDS = -1; // Watchdog自動更新（ロック保持中はTTLを定期更新、異常終了時は自動解放）
     private static final int MAX_RETRY_ATTEMPTS = 3; // 最大再試行回数
     private static final long BASE_RETRY_DELAY_MS = 100; // 再試行基底遅延時間
     private static final int LOCK_SHARD_COUNT = 16; // ロックシャーディングのシャード数

--- a/backend/src/main/java/com/example/cache/service/ResilientCacheService.java
+++ b/backend/src/main/java/com/example/cache/service/ResilientCacheService.java
@@ -98,7 +98,7 @@ public class ResilientCacheService {
      * @return キャッシュされた値、またはフォールバックで取得した値のOptional
      */
     public <T> Optional<T> get(String key, Class<T> type, Supplier<T> fallbackSupplier) {
-        metrics.recordOperation("get");
+        metrics.recordOperation();
 
         // 分散レートリミッターでシステム負荷制限（Redis バックエンド）
         if (!distributedRateLimiter.tryAcquire()) {
@@ -164,7 +164,7 @@ public class ResilientCacheService {
      * @return 設定成功時true、失敗時falseのCompletableFuture
      */
     public <T> CompletableFuture<Boolean> setAsync(String key, T value, Duration ttl) {
-        metrics.recordOperation("set");
+        metrics.recordOperation();
 
         return CompletableFuture.supplyAsync(() -> {
             // 分散レートリミッターでシステム負荷制限（Redis バックエンド）
@@ -210,7 +210,7 @@ public class ResilientCacheService {
      * @return キーと値のマップ（取得できたもののみ）
      */
     public Map<String, Object> getBatch(Set<String> keys) {
-        metrics.recordOperation("batch-get");
+        metrics.recordOperation();
         logger.debug("バッチ取得開始: keys={}", keys.size());
 
         Map<String, Object> results = new HashMap<>();
@@ -259,7 +259,7 @@ public class ResilientCacheService {
      * @return Redis削除成功時true、失敗時false
      */
     public boolean delete(String key) {
-        metrics.recordOperation("delete");
+        metrics.recordOperation();
         logger.debug("キー削除開始: key={}", key);
 
         // Step 2: Redisから削除（回復力パターン付き）
@@ -589,12 +589,8 @@ public class ResilientCacheService {
         private final LongAdder fallbacks  = new LongAdder();
         private final LongAdder errors     = new LongAdder();
 
-        /**
-         * 操作実行を記録
-         *
-         * @param type 操作タイプ（"get", "set", "delete", "batch-get"）
-         */
-        public void recordOperation(String type) {
+        /** 操作実行を記録 */
+        public void recordOperation() {
             operations.increment();
         }
 

--- a/backend/src/main/java/com/example/cache/service/TransactionalLockService.java
+++ b/backend/src/main/java/com/example/cache/service/TransactionalLockService.java
@@ -457,7 +457,10 @@ public class TransactionalLockService {
             // 新しいトランザクションで補償処理を実行
             // 重要: 独立したトランザクションで実行することで、
             // メイン処理の失敗の影響を受けない
-            RTransaction compensationTx = redissonClient.createTransaction(TransactionOptions.defaults());
+            RTransaction compensationTx = redissonClient.createTransaction(TransactionOptions.defaults()
+                    .timeout(TRANSACTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .retryAttempts(MAX_TRANSACTION_RETRIES)
+                    .retryInterval(2, TimeUnit.SECONDS));
             try {
                 logger.info("補償処理開始");
                 compensation.apply(compensationTx);

--- a/backend/src/test/java/com/example/cache/CacheMetricsTest.java
+++ b/backend/src/test/java/com/example/cache/CacheMetricsTest.java
@@ -15,8 +15,8 @@ class CacheMetricsTest {
     @Test
     void recordOperation_incrementsCount() {
         var metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
-        metrics.recordOperation("set");
+        metrics.recordOperation();
+        metrics.recordOperation();
 
         Map<String, Long> map = metrics.toMap();
         assertThat(map.get("operations")).isEqualTo(2L);
@@ -35,7 +35,7 @@ class CacheMetricsTest {
     @Test
     void toMap_hitRateCalculation_correct() {
         var metrics = new ResilientCacheService.CacheMetrics();
-        for (int i = 0; i < 10; i++) metrics.recordOperation("get");
+        for (int i = 0; i < 10; i++) metrics.recordOperation();
         for (int i = 0; i < 7; i++) metrics.recordRedisHit();
 
         Map<String, Long> map = metrics.toMap();
@@ -54,7 +54,7 @@ class CacheMetricsTest {
     @Test
     void reset_clearsAllCounters() {
         var metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
+        metrics.recordOperation();
         metrics.recordRedisHit();
         metrics.recordFallback();
         metrics.recordError();
@@ -71,7 +71,7 @@ class CacheMetricsTest {
     @Test
     void toString_includesAllFields() {
         var metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
+        metrics.recordOperation();
 
         String str = metrics.toString();
         assertThat(str).contains("operations=1");
@@ -91,7 +91,7 @@ class CacheMetricsTest {
                 try {
                     ready.countDown();
                     go.await();
-                    metrics.recordOperation("get");
+                    metrics.recordOperation();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 } finally {

--- a/backend/src/test/java/com/example/cache/controller/CacheControllerTest.java
+++ b/backend/src/test/java/com/example/cache/controller/CacheControllerTest.java
@@ -463,7 +463,7 @@ class CacheControllerTest {
     @Test
     void getMetrics_returns200WithMetricsMap() throws Exception {
         ResilientCacheService.CacheMetrics metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
+        metrics.recordOperation();
         metrics.recordRedisHit();
         when(cacheService.getMetrics()).thenReturn(metrics);
 

--- a/backend/src/test/java/com/example/cache/controller/CliControllerTest.java
+++ b/backend/src/test/java/com/example/cache/controller/CliControllerTest.java
@@ -66,15 +66,11 @@ class CliControllerTest {
     }
 
     @Test
-    void execute_keysCommand_returnsList() throws Exception {
-        RKeys rKeys = mock(RKeys.class);
-        when(rKeys.getKeysStream(any())).thenReturn(Stream.of("key1", "key2"));
-        when(redissonClient.getKeys()).thenReturn(rKeys);
-
+    void execute_keysCommand_rejected() throws Exception {
         mockMvc.perform(post("/api/cli/execute")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"command\":\"KEYS *\"}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -460,18 +456,14 @@ class CliControllerTest {
         verify(bucket).set("hello world");
     }
 
-    // --- KEYS with no pattern defaults to * ---
+    // --- KEYS without pattern also rejected ---
 
     @Test
-    void execute_keysWithoutPattern_usesWildcard() throws Exception {
-        RKeys rKeys = mock(RKeys.class);
-        when(rKeys.getKeysStream(any())).thenReturn(Stream.of("key1"));
-        when(redissonClient.getKeys()).thenReturn(rKeys);
-
+    void execute_keysWithoutPattern_rejected() throws Exception {
         mockMvc.perform(post("/api/cli/execute")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"command\":\"KEYS\"}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isBadRequest());
     }
 
     // --- ZRANGE with empty sorted set → empty list ---

--- a/backend/src/test/java/com/example/cache/service/DistributedLockServiceTest.java
+++ b/backend/src/test/java/com/example/cache/service/DistributedLockServiceTest.java
@@ -75,13 +75,13 @@ class DistributedLockServiceTest {
         @Test
         void delegates_to_overload_with_default_waitTime_and_leaseTime() throws InterruptedException {
             when(redissonClient.getLock("key1")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithLock("key1", () -> "value");
 
             assertThat(result).contains("value");
-            verify(lock).tryLock(10, 30, TimeUnit.SECONDS);
+            verify(lock).tryLock(10, -1, TimeUnit.SECONDS);
         }
     }
 
@@ -95,10 +95,10 @@ class DistributedLockServiceTest {
         @Test
         void lockAcquired_operationSucceeds_returnsValue() throws InterruptedException {
             when(redissonClient.getLock("key1")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
-            Optional<String> result = service.executeWithLock("key1", () -> "hello", 10, 30);
+            Optional<String> result = service.executeWithLock("key1", () -> "hello", 10, -1);
 
             assertThat(result).contains("hello");
             verify(lock).unlock();
@@ -107,10 +107,10 @@ class DistributedLockServiceTest {
         @Test
         void lockAcquired_operationReturnsNull_returnsEmpty() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
-            Optional<String> result = service.executeWithLock("key", () -> null, 10, 30);
+            Optional<String> result = service.executeWithLock("key", () -> null, 10, -1);
 
             assertThat(result).isEmpty();
             verify(lock).unlock();
@@ -119,13 +119,13 @@ class DistributedLockServiceTest {
         @Test
         void lockAcquired_operationThrows_rethrowsAndUnlocks() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             assertThatThrownBy(() ->
                     service.executeWithLock("key", () -> {
                         throw new RuntimeException("boom");
-                    }, 10, 30)
+                    }, 10, -1)
             ).isInstanceOf(RuntimeException.class).hasMessage("boom");
 
             // unlock must still be called in the finally block
@@ -135,13 +135,13 @@ class DistributedLockServiceTest {
         @Test
         void lockAcquired_operationThrows_metricsRecordFailure() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             try {
                 service.executeWithLock("key", () -> {
                     throw new RuntimeException("fail");
-                }, 10, 30);
+                }, 10, -1);
             } catch (RuntimeException ignored) {
             }
 
@@ -154,10 +154,10 @@ class DistributedLockServiceTest {
         @Test
         void lockNotAcquired_tryLockFalse_returnsEmpty() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
-            Optional<String> result = service.executeWithLock("key", () -> "x", 10, 30);
+            Optional<String> result = service.executeWithLock("key", () -> "x", 10, -1);
 
             assertThat(result).isEmpty();
             verify(lock, never()).unlock();
@@ -166,10 +166,10 @@ class DistributedLockServiceTest {
         @Test
         void lockNotAcquired_timeoutMetricRecorded() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
-            service.executeWithLock("key", () -> "x", 10, 30);
+            service.executeWithLock("key", () -> "x", 10, -1);
 
             DistributedLockService.LockMetrics.LockStats stats =
                     service.getMetrics().getAllStats().get("key");
@@ -183,7 +183,7 @@ class DistributedLockServiceTest {
                     .thenThrow(new InterruptedException("interrupted"));
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
-            Optional<String> result = service.executeWithLock("key", () -> "x", 10, 30);
+            Optional<String> result = service.executeWithLock("key", () -> "x", 10, -1);
 
             assertThat(result).isEmpty();
             // Verify that interrupt flag was restored
@@ -195,23 +195,23 @@ class DistributedLockServiceTest {
         @Test
         void unlockThrows_exceptionIsSwallowed_doesNotPropagate() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
             doThrow(new IllegalMonitorStateException("not locked")).when(lock).unlock();
 
             // Must not throw
             assertThatNoException().isThrownBy(() ->
-                    service.executeWithLock("key", () -> "ok", 10, 30));
+                    service.executeWithLock("key", () -> "ok", 10, -1));
         }
 
         @Test
         void lockNotHeldByCurrentThread_unlockNotCalled() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             // Simulate lock no longer held (e.g., lease expired before finally)
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
-            service.executeWithLock("key", () -> "ok", 10, 30);
+            service.executeWithLock("key", () -> "ok", 10, -1);
 
             verify(lock, never()).unlock();
         }
@@ -219,10 +219,10 @@ class DistributedLockServiceTest {
         @Test
         void metricsRecordAttemptAndAcquiredAndSuccess() throws InterruptedException {
             when(redissonClient.getLock("key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
-            service.executeWithLock("key", () -> "result", 10, 30);
+            service.executeWithLock("key", () -> "result", 10, -1);
 
             DistributedLockService.LockMetrics.LockStats stats =
                     service.getMetrics().getAllStats().get("key");
@@ -243,7 +243,7 @@ class DistributedLockServiceTest {
         @Test
         void tokenNotNull_operationExecutes_returnsValue() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(42L);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(42L);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithFencedLock("fkey",
@@ -256,7 +256,7 @@ class DistributedLockServiceTest {
         @Test
         void tokenNull_timeout_returnsEmpty() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(null);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(null);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(false);
 
             Optional<String> result = service.executeWithFencedLock("fkey", token -> "x");
@@ -268,7 +268,7 @@ class DistributedLockServiceTest {
         @Test
         void operationThrows_wrappedInRuntimeException() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(1L);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(1L);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(true);
 
             assertThatThrownBy(() ->
@@ -286,7 +286,7 @@ class DistributedLockServiceTest {
         @Test
         void operationThrows_metricsRecordFailure() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(1L);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(1L);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(true);
 
             try {
@@ -304,7 +304,7 @@ class DistributedLockServiceTest {
         @Test
         void unlockThrows_exceptionSwallowed() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(1L);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(1L);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(true);
             doThrow(new IllegalMonitorStateException("err")).when(fencedLock).unlock();
 
@@ -315,7 +315,7 @@ class DistributedLockServiceTest {
         @Test
         void timeoutMetricRecorded_whenTokenNull() throws Exception {
             when(redissonClient.getFencedLock("fkey")).thenReturn(fencedLock);
-            when(fencedLock.tryLockAndGetToken(10, 30, TimeUnit.SECONDS)).thenReturn(null);
+            when(fencedLock.tryLockAndGetToken(10, -1, TimeUnit.SECONDS)).thenReturn(null);
             when(fencedLock.isHeldByCurrentThread()).thenReturn(false);
 
             service.executeWithFencedLock("fkey", token -> "x");
@@ -341,7 +341,7 @@ class DistributedLockServiceTest {
 
         @Test
         void readLockAcquired_operationExecutes_returnsValue() throws InterruptedException {
-            when(readLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(readLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(readLock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithReadLock("rwkey", () -> "data");
@@ -352,7 +352,7 @@ class DistributedLockServiceTest {
 
         @Test
         void readLockTimeout_returnsEmpty() throws InterruptedException {
-            when(readLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(readLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(readLock.isHeldByCurrentThread()).thenReturn(false);
 
             Optional<String> result = service.executeWithReadLock("rwkey", () -> "data");
@@ -376,7 +376,7 @@ class DistributedLockServiceTest {
 
         @Test
         void readLockNotHeldAfterOperation_unlockSkipped() throws InterruptedException {
-            when(readLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(readLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(readLock.isHeldByCurrentThread()).thenReturn(false);
 
             service.executeWithReadLock("rwkey", () -> "data");
@@ -400,7 +400,7 @@ class DistributedLockServiceTest {
 
         @Test
         void writeLockAcquired_operationExecutes_returnsValue() throws InterruptedException {
-            when(writeLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(writeLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(writeLock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithWriteLock("rwkey", () -> "written");
@@ -411,7 +411,7 @@ class DistributedLockServiceTest {
 
         @Test
         void writeLockTimeout_returnsEmpty() throws InterruptedException {
-            when(writeLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(writeLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(writeLock.isHeldByCurrentThread()).thenReturn(false);
 
             Optional<String> result = service.executeWithWriteLock("rwkey", () -> "written");
@@ -435,7 +435,7 @@ class DistributedLockServiceTest {
 
         @Test
         void writeLockNotHeldAfterOperation_unlockSkipped() throws InterruptedException {
-            when(writeLock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(writeLock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(writeLock.isHeldByCurrentThread()).thenReturn(false);
 
             service.executeWithWriteLock("rwkey", () -> "written");
@@ -454,7 +454,7 @@ class DistributedLockServiceTest {
         @Test
         void fairLockAcquired_operationExecutes_returnsValue() throws InterruptedException {
             when(redissonClient.getFairLock("flock")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithFairLock("flock", () -> "fair-result");
@@ -466,7 +466,7 @@ class DistributedLockServiceTest {
         @Test
         void fairLockTimeout_returnsEmpty() throws InterruptedException {
             when(redissonClient.getFairLock("flock")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
             Optional<String> result = service.executeWithFairLock("flock", () -> "x");
@@ -491,7 +491,7 @@ class DistributedLockServiceTest {
         @Test
         void fairLockNotHeld_unlockSkipped() throws InterruptedException {
             when(redissonClient.getFairLock("flock")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
             service.executeWithFairLock("flock", () -> "x");
@@ -511,20 +511,20 @@ class DistributedLockServiceTest {
         void spinLockAcquired_usesWaitTimeOf5_returnsValue() throws InterruptedException {
             when(redissonClient.getSpinLock("slock")).thenReturn(lock);
             // waitTime must be 5 (not the default 10)
-            when(lock.tryLock(5, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(5, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithSpinLock("slock", () -> "spin-result");
 
             assertThat(result).contains("spin-result");
-            verify(lock).tryLock(5, 30, TimeUnit.SECONDS);
+            verify(lock).tryLock(5, -1, TimeUnit.SECONDS);
             verify(lock).unlock();
         }
 
         @Test
         void spinLockTimeout_returnsEmpty() throws InterruptedException {
             when(redissonClient.getSpinLock("slock")).thenReturn(lock);
-            when(lock.tryLock(5, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(5, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
             Optional<String> result = service.executeWithSpinLock("slock", () -> "x");
@@ -549,7 +549,7 @@ class DistributedLockServiceTest {
         @Test
         void spinLockNotHeld_unlockSkipped() throws InterruptedException {
             when(redissonClient.getSpinLock("slock")).thenReturn(lock);
-            when(lock.tryLock(5, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(5, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
             service.executeWithSpinLock("slock", () -> "x");
@@ -686,7 +686,7 @@ class DistributedLockServiceTest {
             String expectedLockKey = "sharded_lock_" + expectedShard;
 
             when(redissonClient.getLock(expectedLockKey)).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             Optional<String> result = service.executeWithShardedLock("user123", () -> "sharded");
@@ -703,7 +703,7 @@ class DistributedLockServiceTest {
 
             String lockKey = "sharded_lock_" + shard1;
             when(redissonClient.getLock(lockKey)).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             service.executeWithShardedLock("resource-abc", () -> "x");
@@ -734,7 +734,7 @@ class DistributedLockServiceTest {
         @Test
         void operationSucceeds_futureCompletesWithValue() throws Exception {
             when(redissonClient.getLock("akey")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             when(lock.isHeldByCurrentThread()).thenReturn(true);
 
             CompletableFuture<Optional<String>> future =
@@ -747,7 +747,7 @@ class DistributedLockServiceTest {
         @Test
         void lockNotAcquired_futureCompletesWithEmpty() throws Exception {
             when(redissonClient.getLock("akey")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
             when(lock.isHeldByCurrentThread()).thenReturn(false);
 
             CompletableFuture<Optional<String>> future =
@@ -766,7 +766,7 @@ class DistributedLockServiceTest {
             DistributedLockService svc = new DistributedLockService(redissonClient, throwingExecutor);
 
             when(redissonClient.getLock("ex-key")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(true);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(true);
             // Simulate the operation throwing; isHeldByCurrentThread throws so the
             // finally block itself raises an exception that escapes executeWithLock,
             // which means the CompletableFuture completes exceptionally.
@@ -785,7 +785,7 @@ class DistributedLockServiceTest {
         @Test
         void futureIsNotNull() throws Exception {
             when(redissonClient.getLock("akey")).thenReturn(lock);
-            when(lock.tryLock(10, 30, TimeUnit.SECONDS)).thenReturn(false);
+            when(lock.tryLock(10, -1, TimeUnit.SECONDS)).thenReturn(false);
 
             CompletableFuture<Optional<String>> future =
                     service.executeWithLockAsync("akey", () -> "val");

--- a/backend/src/test/java/com/example/cache/service/ResilientCacheServiceIT.java
+++ b/backend/src/test/java/com/example/cache/service/ResilientCacheServiceIT.java
@@ -119,7 +119,7 @@ class ResilientCacheServiceIT {
     @Test
     void cacheMetrics_hitRateCalculation() throws Exception {
         var metrics = new ResilientCacheService.CacheMetrics();
-        for (int i = 0; i < 10; i++) metrics.recordOperation("get");
+        for (int i = 0; i < 10; i++) metrics.recordOperation();
         for (int i = 0; i < 7; i++) metrics.recordRedisHit();
 
         Map<String, Long> map = metrics.toMap();

--- a/backend/src/test/java/com/example/cache/service/ResilientCacheServiceTest.java
+++ b/backend/src/test/java/com/example/cache/service/ResilientCacheServiceTest.java
@@ -367,8 +367,8 @@ class ResilientCacheServiceTest {
     void cacheMetrics_recordAndRead() {
         ResilientCacheService.CacheMetrics metrics = new ResilientCacheService.CacheMetrics();
 
-        metrics.recordOperation("get");
-        metrics.recordOperation("set");
+        metrics.recordOperation();
+        metrics.recordOperation();
         metrics.recordRedisHit();
         metrics.recordFallback();
         metrics.recordError();
@@ -384,7 +384,7 @@ class ResilientCacheServiceTest {
     @Test
     void cacheMetrics_reset_clearsAllCounters() {
         ResilientCacheService.CacheMetrics metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
+        metrics.recordOperation();
         metrics.recordRedisHit();
         metrics.recordFallback();
         metrics.recordError();
@@ -407,7 +407,7 @@ class ResilientCacheServiceTest {
     @Test
     void cacheMetrics_toString_containsStats() {
         ResilientCacheService.CacheMetrics metrics = new ResilientCacheService.CacheMetrics();
-        metrics.recordOperation("get");
+        metrics.recordOperation();
         metrics.recordRedisHit();
 
         String str = metrics.toString();


### PR DESCRIPTION
## Summary
- CliControllerのALLOWED_COMMANDSからKEYSを除外（O(N)ブロッキング防止、SCANで代替可能）
- DistributedLockServiceのDEFAULT_LEASE_TIME_SECONDSを-1に変更しWatchdog自動更新を有効化
- TransactionalLockServiceの補償トランザクションにタイムアウト・リトライ設定を追加
- CacheMetrics.recordOperationの未使用typeパラメータを削除

Closes #27

## Test plan
- [x] `./gradlew compileJava` — コンパイル成功
- [x] `./gradlew test` — 全456テスト通過
- [ ] KEYSコマンドがCLIで拒否されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)