### PR TITLE
P3 フロントエンド改善: バッチ並列化, 404ページ, client.ts修正 (#26)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
           <Route path="/pubsub"          element={<PubSubPage />} />
           <Route path="/saga"            element={<SagaTracerPage />} />
           <Route path="/cli"             element={<RedisCliPage />} />
-          <Route path="*"               element={<div style={{padding:'2rem',textAlign:'center'}}><h2>404 - ページが見つかりません</h2></div>} />
+          <Route path="*"               element={<div className="p-8 text-center"><h2 className="text-xl font-bold mb-4">404 - ページが見つかりません</h2><a href="/" className="text-blue-400 hover:text-blue-300 underline">ホームに戻る</a></div>} />
         </Routes>
         </ErrorBoundary>
       </AppShell>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,7 +37,11 @@ export async function apiFetch<T>(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const headers: Record<string, string> = {};
+  const method = fetchOptions.method?.toUpperCase() ?? 'GET';
+  if (method !== 'GET' && method !== 'DELETE') {
+    headers['Content-Type'] = 'application/json';
+  }
   const apiKey = getApiKey();
   if (apiKey) {
     headers['X-API-Key'] = apiKey;

--- a/frontend/src/components/cache/ValueEditor.tsx
+++ b/frontend/src/components/cache/ValueEditor.tsx
@@ -19,8 +19,8 @@ export function ValueEditor({ initialValue, onSave, onCancel }: ValueEditorProps
     try {
       parsed = JSON.parse(raw);
     } catch {
-      setError('JSON の形式が正しくありません');
-      return;
+      // JSON としてパースできない場合はプレーン文字列として保存
+      parsed = raw;
     }
     setError(null);
     setIsSaving(true);

--- a/frontend/src/pages/CacheExplorerPage.tsx
+++ b/frontend/src/pages/CacheExplorerPage.tsx
@@ -35,8 +35,10 @@ export function CacheExplorerPage() {
       for (let i = 0; i < searchRes.keys.length; i += 50) {
         chunks.push(searchRes.keys.slice(i, i + 50));
       }
-      for (const chunk of chunks) {
-        const res = await cacheApi.batchGet(chunk);
+      const chunkResults = await Promise.all(
+        chunks.map(chunk => cacheApi.batchGet(chunk))
+      );
+      for (const res of chunkResults) {
         Object.assign(allResults, res.results);
       }
       setResults(allResults);

--- a/frontend/src/test/components/cache/ValueEditor.test.tsx
+++ b/frontend/src/test/components/cache/ValueEditor.test.tsx
@@ -78,7 +78,7 @@ describe('ValueEditor', () => {
     })
   })
 
-  it('無効なJSONの場合はエラーメッセージが表示されonSaveは呼ばれない', async () => {
+  it('無効なJSONの場合はプレーン文字列としてonSaveが呼ばれる', async () => {
     const user = userEvent.setup()
 
     render(
@@ -91,8 +91,7 @@ describe('ValueEditor', () => {
 
     await user.click(screen.getByRole('button', { name: '保存' }))
 
-    expect(screen.getByText('JSON の形式が正しくありません')).toBeInTheDocument()
-    expect(mockOnSave).not.toHaveBeenCalled()
+    expect(mockOnSave).toHaveBeenCalledWith('not valid json')
   })
 
   it('キャンセルボタンをクリックするとonCancelが呼ばれる', async () => {
@@ -158,22 +157,25 @@ describe('ValueEditor', () => {
     })
   })
 
-  it('テキストを編集するとエラーメッセージがクリアされる', async () => {
+  it('onSave失敗時のエラーメッセージがテキスト編集でクリアされる', async () => {
     const user = userEvent.setup()
+    mockOnSave.mockRejectedValueOnce(new Error('保存に失敗しました'))
 
     render(
       <ValueEditor
-        initialValue="bad json"
+        initialValue='"valid"'
         onSave={mockOnSave}
         onCancel={mockOnCancel}
       />
     )
 
     await user.click(screen.getByRole('button', { name: '保存' }))
-    expect(screen.getByText('JSON の形式が正しくありません')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('保存に失敗しました')).toBeInTheDocument()
+    })
 
     const textarea = screen.getByRole('textbox')
     await user.type(textarea, ' ')
-    expect(screen.queryByText('JSON の形式が正しくありません')).not.toBeInTheDocument()
+    expect(screen.queryByText('保存に失敗しました')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary
- CacheExplorerPageのバッチフェッチをPromise.allで並列化
- ValueEditorでJSONパース失敗時はプレーン文字列として保存
- 404ページに「ホームに戻る」リンク追加、インラインstyleをTailwindクラスに変更
- client.tsでGET/DELETEリクエストにContent-Typeヘッダーを付与しない
- MSW onUnhandledRequestを'bypass'から'warn'に変更

Closes #26

## Test plan
- [x] `npm test` — 全640テスト通過
- [x] `npm run build` — ビルド成功
- [ ] 404ページで「ホームに戻る」リンクが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)