### PR TITLE
P3 Infra改善: Grafana .env化, Prometheus alerting, Docker改善 (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,8 @@ API_KEY=
 # OpenTelemetry（OTel Collectorを使う場合はコメントアウトを外す）
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
+# Grafana admin password (default: admin)
+GRAFANA_ADMIN_PASSWORD=
+
 # Spring
 SPRING_PROFILES_ACTIVE=docker

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,12 @@ WORKDIR /app
 
 # OpenTelemetry Java Agent
 ARG OTEL_AGENT_VERSION=2.25.0
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar otel-agent.jar
+RUN --mount=type=cache,target=/tmp/otel-cache \
+    if [ ! -f /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar ]; then \
+      wget -q -O /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar \
+        "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar"; \
+    fi && \
+    cp /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar otel-agent.jar
 
 COPY --from=builder /app/build/libs/cache-service.jar app.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - backend
 
   backend:
     build:
@@ -49,6 +51,10 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    networks:
+      - frontend
+      - backend
+      - monitoring
 
   frontend:
     build:
@@ -60,6 +66,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    networks:
+      - frontend
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.120.0
@@ -73,6 +81,9 @@ services:
     depends_on:
       - jaeger
       - loki
+    networks:
+      - backend
+      - monitoring
 
   jaeger:
     image: jaegertracing/jaeger:2.6.0
@@ -81,6 +92,8 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"
+    networks:
+      - monitoring
 
   loki:
     image: grafana/loki:3.4.2
@@ -90,6 +103,8 @@ services:
       - "3100:3100"
     volumes:
       - loki-data:/loki
+    networks:
+      - monitoring
 
   prometheus:
     image: prom/prometheus:v3.4.0
@@ -98,18 +113,22 @@ services:
       - '--web.enable-remote-write-receiver'
     volumes:
       - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./docker/alert-rules.yml:/etc/prometheus/alert-rules.yml
       - prometheus-data:/prometheus
     ports:
       - "9090:9090"
     depends_on:
       backend:
         condition: service_healthy
+    networks:
+      - monitoring
+      - backend
 
   grafana:
     image: grafana/grafana:11.6.0
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     volumes:
@@ -121,6 +140,16 @@ services:
     depends_on:
       - prometheus
       - loki
+    networks:
+      - monitoring
+
+networks:
+  frontend:
+    driver: bridge
+  backend:
+    driver: bridge
+  monitoring:
+    driver: bridge
 
 volumes:
   redis-data:

--- a/docker/alert-rules.yml
+++ b/docker/alert-rules.yml
@@ -1,0 +1,26 @@
+groups:
+  - name: http_alerts
+    rules:
+      - alert: HighHttpErrorRate
+        expr: >
+          sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+          /
+          sum(rate(http_server_requests_seconds_count[5m]))
+          > 0.05
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "HTTP エラーレートが 5% を超過"
+          description: "直近5分間の HTTP 5xx エラーレートが {{ $value | humanizePercentage }} です"
+
+  - name: circuit_breaker_alerts
+    rules:
+      - alert: CircuitBreakerOpen
+        expr: resilience4j_circuitbreaker_state{state="open"} == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "サーキットブレーカー {{ $labels.name }} が OPEN"
+          description: "サーキットブレーカーが OPEN 状態のまま 1 分以上経過しています"

--- a/docker/grafana/dashboards/spring-boot-redis.json
+++ b/docker/grafana/dashboards/spring-boot-redis.json
@@ -1,6 +1,6 @@
 {
   "annotations": { "list": [] },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - '/etc/prometheus/alert-rules.yml'
+
 scrape_configs:
   - job_name: 'spring-boot'
     metrics_path: '/actuator/prometheus'
@@ -9,3 +12,8 @@ scrape_configs:
       - targets: ['backend:8080']
         labels:
           application: 'cache-service'
+
+  - job_name: 'otel-collector'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['otel-collector:8888']

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Serve
-FROM nginx:alpine
+FROM nginx:1.27-alpine
 
 # 非root ユーザーで実行するための準備
 RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx/conf.d && \


### PR DESCRIPTION
## Summary
- Grafana管理者パスワードを.env経由で設定可能に（デフォルト: admin）
- Prometheus alerting rules追加（HTTPエラーレート>5%、CB OPEN検知）
- OTel Collectorのメトリクススクレイプジョブ追加
- nginx:alpineをnginx:1.27-alpineにバージョン固定
- backend DockerfileのADD URL→BuildKit cache mount+wgetに変更
- 明示的Dockerネットワーク定義（frontend/backend/monitoring分離）
- Grafanaダッシュボードをeditable:falseに変更

Closes #25

## Test plan
- [ ] `docker compose config` — 構文検証パス
- [ ] `docker compose up -d --build` — 全サービス起動確認
- [ ] Grafana UIでダッシュボードが編集不可であること確認
- [ ] Prometheus `/api/v1/rules` でアラートルール読み込み確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)