### PR TITLE
test: P3変更のE2Eテスト追加 + インフラ監視スタック検証

### DIFF
--- a/e2e/tests/pages/cache.spec.ts
+++ b/e2e/tests/pages/cache.spec.ts
@@ -41,6 +41,46 @@ test.describe('Cache Explorer (/cache)', () => {
   });
 });
 
+test.describe('ValueEditor — プレーンテキスト保存', () => {
+
+  test('JSON ではないプレーンテキストを保存できる', async ({ page, request }) => {
+    const key = `e2e-plain-${Date.now()}`;
+    await request.post(`/api/cache/set/${key}`, {
+      data: { value: 'original', ttl: 120 },
+    });
+
+    await page.goto(`/cache/${encodeURIComponent(key)}`);
+    await page.waitForLoadState('networkidle');
+
+    // 編集ボタンをクリック
+    const editButton = page.getByRole('button', { name: /編集|edit/i }).first();
+    if (await editButton.isVisible({ timeout: 5_000 })) {
+      await editButton.click();
+
+      // テキストエリアにプレーンテキストを入力
+      const textarea = page.locator('textarea').first();
+      await expect(textarea).toBeVisible({ timeout: 5_000 });
+      await textarea.fill('plain text value');
+
+      // 保存
+      const saveButton = page.getByRole('button', { name: /保存|save/i }).first();
+      await saveButton.click();
+
+      // エラーが表示されないこと（以前は JSON パースエラーになっていた）
+      await expect(page.getByText(/JSON の形式が正しくありません/)).not.toBeVisible();
+    }
+
+    // API で値を確認
+    const getRes = await request.get(`/api/cache/get/${key}`);
+    const body = await getRes.json();
+    if (body.found) {
+      expect(body.value).toBe('plain text value');
+    }
+
+    await request.delete(`/api/cache/delete/${key}`);
+  });
+});
+
 test.describe('Cache Detail (/cache/:key)', () => {
 
   test('存在するキーの詳細ページが表示される', async ({ page, request }) => {

--- a/e2e/tests/pages/cli.spec.ts
+++ b/e2e/tests/pages/cli.spec.ts
@@ -41,6 +41,39 @@ test.describe('Redis CLI (/cli)', () => {
     await request.delete(`/api/cache/delete/${key}`);
   });
 
+  test('KEYS コマンドは拒否される（O(N) ブロッキング防止）', async ({ page }) => {
+    const input = page.locator('input[placeholder*="コマンド"], input[placeholder*="command"], input[type="text"]').first();
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill('KEYS *');
+
+    const execButton = page.getByRole('button', { name: /実行|run|exec/i }).first();
+    if (await execButton.isVisible()) {
+      await execButton.click();
+    } else {
+      await input.press('Enter');
+    }
+
+    await expect(page.getByText(/not allowed|許可されていません|エラー/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('SCAN コマンドは KEYS の代替として動作する', async ({ page }) => {
+    const input = page.locator('input[placeholder*="コマンド"], input[placeholder*="command"], input[type="text"]').first();
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill('SCAN 0');
+
+    const execButton = page.getByRole('button', { name: /実行|run|exec/i }).first();
+    if (await execButton.isVisible()) {
+      await execButton.click();
+    } else {
+      await input.press('Enter');
+    }
+
+    // SCAN の結果が表示される（エラーではない）
+    await expect(page.getByText(/not allowed|許可されていません/i)).not.toBeVisible();
+    // redis> SCAN 0 が表示される
+    await expect(page.getByText('redis> SCAN 0')).toBeVisible({ timeout: 10_000 });
+  });
+
   test('ホワイトリスト外コマンドは拒否される', async ({ page }) => {
     const input = page.locator('input[placeholder*="コマンド"], input[placeholder*="command"], input[type="text"]').first();
     await expect(input).toBeVisible({ timeout: 10_000 });

--- a/e2e/tests/pages/not-found.spec.ts
+++ b/e2e/tests/pages/not-found.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('404 ページ (/nonexistent)', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/this-page-does-not-exist');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('404 テキストが表示される', async ({ page }) => {
+    await expect(page.getByText('404')).toBeVisible();
+    await expect(page.getByText('ページが見つかりません')).toBeVisible();
+  });
+
+  test('「ホームに戻る」リンクが表示される', async ({ page }) => {
+    const homeLink = page.getByRole('link', { name: /ホームに戻る/ });
+    await expect(homeLink).toBeVisible();
+    await expect(homeLink).toHaveAttribute('href', '/');
+  });
+
+  test('「ホームに戻る」クリックでダッシュボードに遷移する', async ({ page }) => {
+    const homeLink = page.getByRole('link', { name: /ホームに戻る/ });
+    await homeLink.click();
+    await page.waitForLoadState('networkidle');
+
+    // ダッシュボードが表示されること
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('heading', { name: /ダッシュボード/ })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/tests/smoke/infrastructure.spec.ts
+++ b/e2e/tests/smoke/infrastructure.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * インフラ監視スタック検証 — Prometheus / Grafana / OTel Collector
+ * Docker Compose 環境で監視基盤が正常に動作していることを確認する
+ */
+
+test.describe('Prometheus', () => {
+
+  test('アラートルールが 2 グループ読み込まれている', async ({ request }) => {
+    const res = await request.fetch('http://localhost:9090/api/v1/rules');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('success');
+
+    const groups = body.data.groups as Array<{ name: string; rules: unknown[] }>;
+    const groupNames = groups.map(g => g.name);
+    expect(groupNames).toContain('http_alerts');
+    expect(groupNames).toContain('circuit_breaker_alerts');
+
+    // 各グループにルールが存在すること
+    for (const group of groups) {
+      expect(group.rules.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('spring-boot スクレイプターゲットが UP', async ({ request }) => {
+    const res = await request.fetch('http://localhost:9090/api/v1/targets');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+
+    const targets = body.data.activeTargets as Array<{ labels: { job: string }; health: string }>;
+    const springBoot = targets.find(t => t.labels.job === 'spring-boot');
+    expect(springBoot).toBeDefined();
+    expect(springBoot!.health).toBe('up');
+  });
+
+  test('otel-collector スクレイプターゲットが存在する', async ({ request }) => {
+    const res = await request.fetch('http://localhost:9090/api/v1/targets');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+
+    const targets = body.data.activeTargets as Array<{ labels: { job: string }; health: string }>;
+    const otelCollector = targets.find(t => t.labels.job === 'otel-collector');
+    expect(otelCollector).toBeDefined();
+  });
+});
+
+test.describe('Grafana', () => {
+
+  test('ダッシュボードが存在する', async ({ request }) => {
+    const res = await request.fetch('http://localhost:3000/api/search?type=dash-db');
+    expect(res.status()).toBe(200);
+    const dashboards = await res.json() as Array<{ uid: string; title: string }>;
+    expect(dashboards.length).toBeGreaterThan(0);
+
+    const redisDash = dashboards.find(d => d.uid === 'spring-boot-redis');
+    expect(redisDash).toBeDefined();
+  });
+
+  test('ダッシュボードが editable: false に設定されている', async ({ request }) => {
+    const res = await request.fetch('http://localhost:3000/api/dashboards/uid/spring-boot-redis');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.dashboard.editable).toBe(false);
+  });
+
+  test('データソース（Prometheus + Loki）がプロビジョニングされている', async ({ request }) => {
+    const res = await request.fetch('http://localhost:3000/api/datasources');
+    expect(res.status()).toBe(200);
+    const datasources = await res.json() as Array<{ type: string; name: string }>;
+    const types = datasources.map(d => d.type);
+    expect(types).toContain('prometheus');
+    expect(types).toContain('loki');
+  });
+});


### PR DESCRIPTION
## Summary
- CLI: KEYSコマンド拒否、SCAN代替動作のE2Eテスト追加
- 404ページ: テキスト表示・ホームリンク・遷移の3テスト新規追加
- Cache: ValueEditorプレーンテキスト保存テスト追加
- Infrastructure: Prometheus alerting rules/scrape targets、Grafana dashboard editable:false/データソースの検証テスト新規追加

## Test plan
- [x] `npx playwright test` — 59テスト全件通過（48.6s）
- [x] 新規テスト11件が全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)