### PR TITLE
fix: BE Security — API認証タイミング攻撃対策 + Actuator保護

### DIFF
--- a/backend/src/main/java/com/example/cache/config/ApiKeyAuthFilter.java
+++ b/backend/src/main/java/com/example/cache/config/ApiKeyAuthFilter.java
@@ -4,6 +4,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -12,15 +14,23 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 
 @Component
 public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(ApiKeyAuthFilter.class);
+
     private final String apiKey;
 
     public ApiKeyAuthFilter(@Value("${api.key:}") String apiKey) {
         this.apiKey = apiKey;
+        if (apiKey.isEmpty()) {
+            log.warn("API_KEY is not configured. All requests will be granted DEMO_ADMIN access. "
+                    + "Set API_KEY environment variable for production use.");
+        }
     }
 
     @Override
@@ -28,7 +38,6 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
                                      HttpServletResponse response,
                                      FilterChain filterChain) throws ServletException, IOException {
         if (apiKey.isEmpty()) {
-            // Dev mode: no API key configured, grant full access
             var auth = new UsernamePasswordAuthenticationToken(
                 "dev-user", null,
                 List.of(new SimpleGrantedAuthority("ROLE_USER"),
@@ -40,7 +49,9 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
         }
 
         String requestApiKey = request.getHeader("X-API-Key");
-        if (apiKey.equals(requestApiKey)) {
+        if (requestApiKey != null && MessageDigest.isEqual(
+                apiKey.getBytes(StandardCharsets.UTF_8),
+                requestApiKey.getBytes(StandardCharsets.UTF_8))) {
             var auth = new UsernamePasswordAuthenticationToken(
                 "api-key-user", null,
                 List.of(new SimpleGrantedAuthority("ROLE_USER"),
@@ -56,7 +67,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
         return path.startsWith("/health")
-            || path.startsWith("/actuator")
+            || path.equals("/actuator/health")
+            || path.startsWith("/actuator/health/")
             || path.startsWith("/swagger-ui")
             || path.startsWith("/v3/api-docs");
     }

--- a/backend/src/main/java/com/example/cache/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/cache/config/SecurityConfig.java
@@ -18,7 +18,8 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/health/**", "/actuator/**").permitAll()
+                .requestMatchers("/health/**", "/actuator/health/**").permitAll()
+                .requestMatchers("/actuator/**").authenticated()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/cache/simulate-error", "/api/cache/reset-circuit-breaker").hasRole("DEMO_ADMIN")
                 .requestMatchers("/api/lock/release").hasRole("DEMO_ADMIN")

--- a/backend/src/test/java/com/example/cache/config/SecurityConfigIT.java
+++ b/backend/src/test/java/com/example/cache/config/SecurityConfigIT.java
@@ -97,4 +97,31 @@ class SecurityConfigIT {
         mockMvc.perform(post("/api/lock/release"))
                 .andExpect(status().isForbidden());
     }
+
+    // --- Actuator endpoints ---
+
+    @Test
+    void actuator_health_accessible_without_auth() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void actuator_prometheus_rejected_without_api_key() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void actuator_prometheus_accessible_with_valid_api_key() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header("X-API-Key", TEST_API_KEY))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void actuator_metrics_rejected_without_api_key() throws Exception {
+        mockMvc.perform(get("/actuator/metrics"))
+                .andExpect(status().isForbidden());
+    }
 }


### PR DESCRIPTION
## Summary
- APIキー比較を `MessageDigest.isEqual()` に変更しタイミング攻撃を防止
- `requestApiKey` の null ガード追加
- API_KEY 未設定時の起動警告ログ追加
- Actuator エンドポイントを `/actuator/health` のみ公開、`/prometheus` `/metrics` は認証必須に変更
- SecurityConfigIT に actuator 認証テスト4件追加

Closes #33

## Test plan
- [x] `./gradlew test` 全テストパス
- [x] SecurityConfigIT: actuator/health は認証なしで200
- [x] SecurityConfigIT: actuator/prometheus は認証なしで403、認証ありで200
- [x] SecurityConfigIT: actuator/metrics は認証なしで403

🤖 Generated with [Claude Code](https://claude.com/claude-code)