### PR TITLE
fix: FE Type Safety — ロックAPIレスポンス型定義 + handleSaveエラー��ンドリング

### DIFF
--- a/frontend/src/api/locks.ts
+++ b/frontend/src/api/locks.ts
@@ -2,6 +2,7 @@ import { apiFetch } from './client';
 import type {
   LockAcquireRequest, LockAcquireResponse,
   LockExecuteRequest, FencedLockRequest,
+  FencedLockResponse, LockExecuteResponse,
   LockStatusResponse, LockMetricsResponse,
   TransferRequest, TransferResponse,
   LockDemoRunRequest, LockDemoResponse,
@@ -14,12 +15,12 @@ export const locksApi = {
     }),
 
   acquireFenced: (body: FencedLockRequest) =>
-    apiFetch<Record<string, unknown>>('/api/lock/acquire-fenced', {
+    apiFetch<FencedLockResponse>('/api/lock/acquire-fenced', {
       method: 'POST', body: JSON.stringify(body)
     }),
 
   execute: (body: LockExecuteRequest) =>
-    apiFetch<Record<string, unknown>>('/api/lock/execute', {
+    apiFetch<LockExecuteResponse>('/api/lock/execute', {
       method: 'POST', body: JSON.stringify(body)
     }),
 

--- a/frontend/src/pages/CacheDetailPage.tsx
+++ b/frontend/src/pages/CacheDetailPage.tsx
@@ -42,12 +42,16 @@ export function CacheDetailPage() {
   }, [decodedKey]);
 
   const handleSave = async (parsed: unknown) => {
-    await cacheApi.set(decodedKey, { value: parsed });
-    const refreshed = await cacheApi.get(decodedKey);
-    setEntry(refreshed);
-    setFetchedAt(new Date());
-    setIsEditing(false);
-    addToast('保存しました', 'success');
+    try {
+      await cacheApi.set(decodedKey, { value: parsed });
+      const refreshed = await cacheApi.get(decodedKey);
+      setEntry(refreshed);
+      setFetchedAt(new Date());
+      setIsEditing(false);
+      addToast('保存しました', 'success');
+    } catch (e) {
+      addToast(e instanceof Error ? e.message : '保存に失敗しました', 'error');
+    }
   };
 
   const handleDelete = async () => {

--- a/frontend/src/test/pages/CacheDetailPage.test.tsx
+++ b/frontend/src/test/pages/CacheDetailPage.test.tsx
@@ -67,7 +67,7 @@ describe('CacheDetailPage', () => {
       found: true,
       value: 'Hello, Redis!',
     })
-    mockSet.mockResolvedValue({ key: 'demo:greeting', success: true })
+    mockSet.mockResolvedValue({ key: 'demo:greeting', success: true, ttl: 'PT5M' })
     mockDelete.mockResolvedValue({ key: 'demo:greeting', deleted: true })
   })
 

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -80,11 +80,8 @@ describe('DashboardPage', () => {
       hitRate: 75,
     })
     mockLocksMetrics.mockResolvedValue({
-      totalAcquired: 5,
-      totalReleased: 4,
-      totalFailed: 1,
-      currentlyHeld: 1,
-      locks: [],
+      locks: {},
+      timestamp: Date.now(),
     })
   })
 

--- a/frontend/src/types/locks.ts
+++ b/frontend/src/types/locks.ts
@@ -35,6 +35,18 @@ export interface FencedLockRequest {
   data?: Record<string, unknown>;
 }
 
+export interface FencedLockResponse {
+  lockKey: string;
+  acquired: boolean;
+  fencingToken: number | null;
+  timestamp: number;
+  [key: string]: unknown;
+}
+
+export interface LockExecuteResponse {
+  [key: string]: unknown;
+}
+
 export interface LockStatusResponse {
   lockKey: string;
   locked: boolean;


### PR DESCRIPTION
## Summary
- `CacheDetailPage.handleSave` に try/catch 追加（エラートースト表示）
- `FencedLockResponse` / `LockExecuteResponse` 型インターフェース追加
- `api/locks.ts` の `Record<string, unknown>` を型付きレスポンスに変更
- `DashboardPage.test.tsx`: ロックメトリクスモックを `LockMetricsResponse` に合わせて修正
- `CacheDetailPage.test.tsx`: `mockSet` に欠落してい�� `ttl` フィールド追加

Closes #35

## Test plan
- [x] `npm run lint` — エラーなし
- [x] `npm test` — 639テスト全パス
- [x] `npm run build` — ���ルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)