### PR TITLE
fix: Infra Hardening — ポートバインド制限 + リソース制限 + OTelチェックサム

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,14 +10,16 @@ RUN gradle bootJar --no-daemon
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
-# OpenTelemetry Java Agent
+# OpenTelemetry Java Agent (with SHA-256 integrity check)
 ARG OTEL_AGENT_VERSION=2.25.0
+ARG OTEL_AGENT_SHA256=d6e809824176cf88792db359a9d928281ba2102fa8755453c1940f6c0289e396
 RUN --mount=type=cache,target=/tmp/otel-cache \
     if [ ! -f /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar ]; then \
       wget -q -O /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar \
         "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar"; \
     fi && \
-    cp /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar otel-agent.jar
+    cp /tmp/otel-cache/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar otel-agent.jar && \
+    echo "${OTEL_AGENT_SHA256}  otel-agent.jar" | sha256sum -c -
 
 COPY --from=builder /app/build/libs/cache-service.jar app.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     ports:
       - "127.0.0.1:6379:6379"
+    mem_limit: 256m
+    cpus: '0.5'
     volumes:
       - redis-data:/data
     healthcheck:
@@ -32,7 +34,9 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
+    mem_limit: 768m
+    cpus: '1.0'
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
@@ -63,6 +67,8 @@ services:
     restart: unless-stopped
     ports:
       - "80:8080"
+    mem_limit: 128m
+    cpus: '0.5'
     depends_on:
       backend:
         condition: service_healthy
@@ -76,8 +82,10 @@ services:
       - ./docker/otel-collector-config.yaml:/etc/otel/config.yaml
     command: ["--config=/etc/otel/config.yaml"]
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    mem_limit: 256m
+    cpus: '0.5'
     depends_on:
       - jaeger
       - loki
@@ -91,7 +99,9 @@ services:
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     ports:
-      - "16686:16686"
+      - "127.0.0.1:16686:16686"
+    mem_limit: 512m
+    cpus: '0.5'
     networks:
       - monitoring
 
@@ -100,7 +110,9 @@ services:
     restart: unless-stopped
     command: ["-config.file=/etc/loki/local-config.yaml"]
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
+    mem_limit: 256m
+    cpus: '0.5'
     volumes:
       - loki-data:/loki
     networks:
@@ -116,7 +128,9 @@ services:
       - ./docker/alert-rules.yml:/etc/prometheus/alert-rules.yml
       - prometheus-data:/prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
+    mem_limit: 256m
+    cpus: '0.5'
     depends_on:
       backend:
         condition: service_healthy
@@ -136,7 +150,9 @@ services:
       - ./docker/grafana/dashboards:/var/lib/grafana/dashboards
       - grafana-data:/var/lib/grafana
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
+    mem_limit: 256m
+    cpus: '0.5'
     depends_on:
       - prometheus
       - loki

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -2,6 +2,14 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# NOTE: Alertmanager is not configured in this demo project.
+# Alert rules in alert-rules.yml are evaluated but notifications are not sent.
+# To enable alerting, add an Alertmanager service and uncomment:
+# alerting:
+#   alertmanagers:
+#     - static_configs:
+#         - targets: ['alertmanager:9093']
+
 rule_files:
   - '/etc/prometheus/alert-rules.yml'
 


### PR DESCRIPTION
## Summary
- 監視系ポート (otel-collector, jaeger, loki, prometheus, grafana, backend) を `127.0.0.1` バインドに変更
- 全コンテナに `mem_limit` + `cpus` を設定
- `prometheus.yml` に Alertmanager 設定例をコメント記載し未構成状態を明示化
- OTel Java Agent のダウンロード後に SHA-256 チェックサム検証を追加

Closes #37

## Test plan
- [ ] `docker compose build` でイメージビルド成功
- [ ] `docker compose up -d` で全サービス起動
- [ ] `docker compose ps` でヘルスチェック通過
- [ ] ポートバインドが `127.0.0.1` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)