### PR TITLE
fix: BE Mid — Resilience改善 + コード品質 (#39)

### DIFF
--- a/backend/src/main/java/com/example/cache/controller/CacheController.java
+++ b/backend/src/main/java/com/example/cache/controller/CacheController.java
@@ -2,7 +2,6 @@ package com.example.cache.controller;
 
 import com.example.cache.service.CacheMetadataService;
 import com.example.cache.service.ResilientCacheService;
-import com.example.cache.util.TypeResolver;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -53,14 +52,12 @@ public class CacheController {
     })
     @GetMapping("/get/{key}")
     public ResponseEntity<Map<String, Object>> getCache(
-            @Parameter(description = "Redis キー") @PathVariable String key,
-            @Parameter(description = "値の型（String/Integer/Long/Double/Boolean/Map/List）") @RequestParam(required = false) String type) {
+            @Parameter(description = "Redis キー") @PathVariable String key) {
 
         Optional<ResponseEntity<Map<String, Object>>> keyError = validateKey(key);
         if (keyError.isPresent()) return keyError.get();
 
-        Class<?> valueClass = type != null ? TypeResolver.fromString(type) : String.class;
-        Optional<?> value = cacheService.get(key, valueClass, null);
+        Optional<?> value = cacheService.get(key, null);
 
         Map<String, Object> result = new HashMap<>();
         result.put("key", key);
@@ -189,11 +186,11 @@ public class CacheController {
         Duration ttl = Duration.ofHours(1);
         if (body.containsKey("ttl")) {
             Object ttlValue = body.get("ttl");
-            if (ttlValue instanceof Number) {
-                ttl = Duration.ofSeconds(((Number) ttlValue).longValue());
-            } else if (ttlValue instanceof String) {
+            if (ttlValue instanceof Number n) {
+                ttl = Duration.ofSeconds(n.longValue());
+            } else if (ttlValue instanceof String s) {
                 try {
-                    ttl = Duration.parse((String) ttlValue);
+                    ttl = Duration.parse(s);
                 } catch (DateTimeParseException e) {
                     return ResponseEntity.badRequest().body(Map.of(
                             "error", "Invalid ttl format. Use ISO-8601 duration (e.g. PT1H) or omit for default",
@@ -255,12 +252,12 @@ public class CacheController {
             Duration ttl = Duration.ofHours(1);
             if (entry.containsKey("ttl")) {
                 Object ttlValue = entry.get("ttl");
-                if (!(ttlValue instanceof Number)) {
+                if (!(ttlValue instanceof Number n)) {
                     return ResponseEntity.badRequest().body(Map.of(
                             "error", "Entry at index " + i + ": 'ttl' must be a number (seconds)",
                             "timestamp", System.currentTimeMillis()));
                 }
-                ttl = Duration.ofSeconds(((Number) ttlValue).longValue());
+                ttl = Duration.ofSeconds(n.longValue());
             }
 
             futures.add(cacheService.setAsync(key, value, ttl));

--- a/backend/src/main/java/com/example/cache/controller/LockController.java
+++ b/backend/src/main/java/com/example/cache/controller/LockController.java
@@ -294,13 +294,13 @@ public class LockController {
         String toKey = (String) body.get("toKey");
         Object amountObj = body.get("amount");
 
-        if (fromKey == null || toKey == null || !(amountObj instanceof Number)) {
+        if (fromKey == null || toKey == null || !(amountObj instanceof Number amountNum)) {
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "fromKey, toKey, and positive amount are required",
                     "timestamp", System.currentTimeMillis()));
         }
 
-        double amount = ((Number) amountObj).doubleValue();
+        double amount = amountNum.doubleValue();
         if (amount <= 0) {
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "fromKey, toKey, and positive amount are required",

--- a/backend/src/main/java/com/example/cache/service/LockDemoOrchestrator.java
+++ b/backend/src/main/java/com/example/cache/service/LockDemoOrchestrator.java
@@ -1,6 +1,5 @@
 package com.example.cache.service;
 
-import com.example.cache.util.TypeResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -82,17 +81,14 @@ public class LockDemoOrchestrator {
         return lockService.executeWithFencedLock(lockKey, (Long fencingToken) -> {
             String readKey = (String) data.get("key");
             if (readKey == null) throw new IllegalArgumentException("'key' is required for fenced_cache_read");
-            String type = (String) data.getOrDefault("type", "Object");
-            Class<?> valueClass = TypeResolver.fromString(type);
 
-            Optional<?> value = cacheService.get(readKey, valueClass, null);
+            Optional<?> value = cacheService.get(readKey, null);
             Map<String, Object> r = new HashMap<>();
             r.put("operation", "fenced_cache_read");
             r.put("fencingToken", fencingToken);
             r.put("key", readKey);
             r.put("found", value.isPresent());
             r.put("value", value.orElse(null));
-            r.put("type", type);
             return r;
         });
     }
@@ -136,7 +132,7 @@ public class LockDemoOrchestrator {
             if (incrementNum == null) throw new IllegalArgumentException("'increment' is required for fenced_atomic_increment");
             int increment = incrementNum.intValue();
 
-            Optional<Integer> current = cacheService.get(counterKey, Integer.class, () -> 0);
+            Optional<Integer> current = cacheService.get(counterKey, () -> 0);
             int newValue = current.orElse(0) + increment;
 
             cacheService.setAsync(counterKey, newValue, Duration.ofDays(1)).join();
@@ -157,10 +153,8 @@ public class LockDemoOrchestrator {
             if (targetKey == null) throw new IllegalArgumentException("'key' is required for fenced_conditional_update");
             Object expectedValue = data.get("expectedValue");
             Object newValue = data.get("newValue");
-            String type = (String) data.getOrDefault("type", "Object");
-            Class<?> valueClass = TypeResolver.fromString(type);
 
-            Optional<?> currentValue = cacheService.get(targetKey, valueClass, null);
+            Optional<?> currentValue = cacheService.get(targetKey, null);
             boolean updated = false;
 
             if (currentValue.isPresent() && currentValue.get().equals(expectedValue)) {
@@ -197,15 +191,12 @@ public class LockDemoOrchestrator {
     private Optional<Map<String, Object>> lockCacheRead(String lockKey, Map<String, Object> data) {
         return lockService.executeWithReadLock(lockKey, () -> {
             String readKey = (String) data.get("key");
-            String type = (String) data.getOrDefault("type", "Object");
-            Class<?> valueClass = TypeResolver.fromString(type);
 
-            Optional<?> value = cacheService.get(readKey, valueClass, null);
+            Optional<?> value = cacheService.get(readKey, null);
             Map<String, Object> r = new HashMap<>();
             r.put("key", readKey);
             r.put("found", value.isPresent());
             r.put("value", value.orElse(null));
-            r.put("type", type);
             return r;
         });
     }
@@ -223,7 +214,7 @@ public class LockDemoOrchestrator {
             String counterKey = (String) data.get("counterKey");
             int increment = ((Number) data.get("increment")).intValue();
 
-            Optional<Integer> current = cacheService.get(counterKey, Integer.class, () -> 0);
+            Optional<Integer> current = cacheService.get(counterKey, () -> 0);
             int newValue = current.orElse(0) + increment;
 
             cacheService.setAsync(counterKey, newValue, Duration.ofDays(1)).join();

--- a/backend/src/main/java/com/example/cache/service/PubSubService.java
+++ b/backend/src/main/java/com/example/cache/service/PubSubService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -29,9 +30,11 @@ public class PubSubService {
     private static final int MAX_EMITTERS = 100;
 
     private final RedissonClient redissonClient;
+    private final ExecutorService virtualExecutor;
 
-    public PubSubService(RedissonClient redissonClient) {
+    public PubSubService(RedissonClient redissonClient, ExecutorService virtualThreadExecutor) {
         this.redissonClient = redissonClient;
+        this.virtualExecutor = virtualThreadExecutor;
     }
 
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
@@ -63,7 +66,8 @@ public class PubSubService {
             RTopic rTopic = redissonClient.getTopic(topic);
             int listenerId = rTopic.addListener(String.class, (channel, msg) -> {
                 logger.info("受信: topic={}, message={}", channel, msg);
-                broadcastToEmitters(topic, msg);
+                // Netty スレッドから Virtual Thread に切り替えて SSE 送信を実行
+                virtualExecutor.execute(() -> broadcastToEmitters(topic, msg));
             });
             topicListenerIds.put(topic, listenerId);
             logger.info("トピック購読開始: {}", topic);

--- a/backend/src/main/java/com/example/cache/service/ResilientCacheService.java
+++ b/backend/src/main/java/com/example/cache/service/ResilientCacheService.java
@@ -1,5 +1,7 @@
 package com.example.cache.service;
 
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.decorators.Decorators;
@@ -38,6 +40,7 @@ import java.util.function.Supplier;
  * ※ローカル（インプロセス）キャッシュは現在未実装
  *
  * ## 回復力パターン
+ * - **Bulkhead**: 並行呼び出し数の制限（Virtual Threads 環境でのリソース保護）
  * - **CircuitBreaker**: 連続的な障害時の呼び出し停止
  * - **Retry**: 一時的障害に対する自動再試行
  * - **RateLimiter**: Redis バックエンド分散レートリミッター（{@link DistributedRateLimiterService}）
@@ -63,6 +66,7 @@ public class ResilientCacheService {
     // Resilience4jコンポーネント（回復力パターン実装）
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
+    private final Bulkhead bulkhead;
 
     // Redis バックエンドの分散レートリミッター
     private final DistributedRateLimiterService distributedRateLimiter;
@@ -70,11 +74,13 @@ public class ResilientCacheService {
     public ResilientCacheService(RedissonClient redissonClient,
                                  CircuitBreakerRegistry circuitBreakerRegistry,
                                  RetryRegistry retryRegistry,
+                                 BulkheadRegistry bulkheadRegistry,
                                  DistributedRateLimiterService distributedRateLimiter,
                                  ExecutorService virtualThreadExecutor) {
         this.redissonClient = redissonClient;
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("cache-operations");
         this.retry = retryRegistry.retry("default");
+        this.bulkhead = bulkheadRegistry.bulkhead("cache-operations");
         this.distributedRateLimiter = distributedRateLimiter;
         this.virtualExecutor = virtualThreadExecutor;
     }
@@ -93,11 +99,10 @@ public class ResilientCacheService {
      *
      * @param <T>              キャッシュする値の型
      * @param key              キャッシュキー
-     * @param type             期待する値の型（キャスト用）
      * @param fallbackSupplier キャッシュミス時のデータ取得関数
      * @return キャッシュされた値、またはフォールバックで取得した値のOptional
      */
-    public <T> Optional<T> get(String key, Class<T> type, Supplier<T> fallbackSupplier) {
+    public <T> Optional<T> get(String key, Supplier<T> fallbackSupplier) {
         metrics.recordOperation();
 
         // 分散レートリミッターでシステム負荷制限（Redis バックエンド）
@@ -108,12 +113,13 @@ public class ResilientCacheService {
         }
 
         // L1: Redis操作を回復力パターンでラップ
-        Supplier<Optional<T>> redisOperation = () -> getFromRedis(key, type);
+        Supplier<Optional<T>> redisOperation = () -> getFromRedis(key);
 
         // Decoratorsパターンで複数の回復力パターンを組み合わせ
         // 実行順序: Retry → CircuitBreaker → 実際のRedis操作
         // （レートリミットは上で事前チェック済み）
         Optional<T> result = Decorators.ofSupplier(redisOperation)
+                .withBulkhead(bulkhead) // 並行数制限で Virtual Threads のスレッド爆発を防止
                 .withCircuitBreaker(circuitBreaker) // サーキットブレーカーで障害時の呼び出し停止
                 .withRetry(retry) // 一時的障害に対する再試行
                 .withFallback(Arrays.asList( // 特定例外に対するフォールバック
@@ -178,6 +184,7 @@ public class ResilientCacheService {
 
             // Redis書き込み操作を回復力パターンで保護
             boolean redisResult = Decorators.ofSupplier(operation)
+                    .withBulkhead(bulkhead)
                     .withCircuitBreaker(circuitBreaker)
                     .withRetry(retry)
                     .withFallback(Arrays.asList(
@@ -225,6 +232,7 @@ public class ResilientCacheService {
         Supplier<Map<String, Object>> batchOperation = () -> getBatchFromRedis(missingKeys);
 
         Map<String, Object> redisResults = Decorators.ofSupplier(batchOperation)
+                .withBulkhead(bulkhead)
                 .withCircuitBreaker(circuitBreaker)
                 .withRetry(retry)
                 .withFallback(Arrays.asList(Exception.class), throwable -> {
@@ -264,6 +272,7 @@ public class ResilientCacheService {
 
         // Step 2: Redisから削除（回復力パターン付き）
         boolean result = Decorators.ofSupplier(() -> deleteFromRedis(key))
+                .withBulkhead(bulkhead)
                 .withCircuitBreaker(circuitBreaker)
                 .withRetry(retry)
                 .withFallback(Arrays.asList(Exception.class), throwable -> {
@@ -304,6 +313,7 @@ public class ResilientCacheService {
         }
 
         Set<String> results = Decorators.ofSupplier(() -> searchKeysInRedis(pattern, limit))
+                .withBulkhead(bulkhead)
                 .withCircuitBreaker(circuitBreaker)
                 .withFallback(Arrays.asList(Exception.class), throwable -> {
                     logger.warn("キー検索失敗: pattern={}", pattern, throwable);
@@ -325,10 +335,9 @@ public class ResilientCacheService {
      *
      * @param <T>  値の型
      * @param key  キー
-     * @param type 期待する型
      * @return 取得した値のOptional
      */
-    private <T> Optional<T> getFromRedis(String key, Class<T> type) {
+    private <T> Optional<T> getFromRedis(String key) {
         if (simulateError) {
             throw new RuntimeException("エラーシミュレーション中: 意図的に障害を注入しています");
         }
@@ -493,28 +502,30 @@ public class ResilientCacheService {
      * @return ウォームアップ完了を示すCompletableFuture
      */
     public CompletableFuture<Void> warmUp(Set<String> keys) {
-        return CompletableFuture.runAsync(() -> {
-            logger.info("キャッシュウォームアップ開始: keys={}", keys.size());
-            long startTime = System.currentTimeMillis();
+        logger.info("キャッシュウォームアップ開始: keys={}", keys.size());
+        long startTime = System.currentTimeMillis();
+        AtomicInteger successCount = new AtomicInteger(0);
 
-            int successCount = 0;
-            for (String key : keys) {
-                try {
-                    // 各キーに対してget操作を実行（フォールバックはnull）
-                    Optional<Object> result = get(key, Object.class, null);
-                    if (result.isPresent()) {
-                        successCount++;
+        // 各キーを個別の Virtual Thread で並行実行
+        List<CompletableFuture<Void>> futures = keys.stream()
+                .map(key -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Optional<Object> result = get(key, null);
+                        if (result.isPresent()) {
+                            successCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        logger.debug("ウォームアップでキー処理失敗: key={}", key, e);
                     }
-                } catch (Exception e) {
-                    logger.debug("ウォームアップでキー処理失敗: key={}", key, e);
-                    // 個別の失敗は継続（部分的成功を許可）
-                }
-            }
+                }, virtualExecutor))
+                .toList();
 
-            long duration = System.currentTimeMillis() - startTime;
-            logger.info("キャッシュウォームアップ完了: total={}, success={}, duration={}ms",
-                    keys.size(), successCount, duration);
-        }, virtualExecutor);
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenRun(() -> {
+                    long duration = System.currentTimeMillis() - startTime;
+                    logger.info("キャッシュウォームアップ完了: total={}, success={}, duration={}ms",
+                            keys.size(), successCount.get(), duration);
+                });
     }
 
     /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -53,6 +53,11 @@ resilience4j:
           - org.redisson.client.RedisConnectionException
           - org.redisson.client.RedisTimeoutException
           - java.io.IOException
+  bulkhead:
+    instances:
+      cache-operations:
+        max-concurrent-calls: 50
+        max-wait-duration: 500ms
   # NOTE: この Resilience4j ratelimiter 設定は参照用に残している。
   # キャッシュ操作のレート制限は Redis バックエンドの分散レートリミッター
   # (DistributedRateLimiterService / Redisson RRateLimiter) に移行済み。

--- a/backend/src/test/java/com/example/cache/controller/CacheControllerTest.java
+++ b/backend/src/test/java/com/example/cache/controller/CacheControllerTest.java
@@ -45,7 +45,7 @@ class CacheControllerTest {
 
     @Test
     void getCache_keyFound_returns200() throws Exception {
-        when(cacheService.get(eq("mykey"), any(), isNull()))
+        when(cacheService.get(eq("mykey"), isNull()))
                 .thenReturn(Optional.of("hello"));
 
         mockMvc.perform(get("/api/cache/get/mykey"))
@@ -57,7 +57,7 @@ class CacheControllerTest {
 
     @Test
     void getCache_keyNotFound_returnsFoundFalse() throws Exception {
-        when(cacheService.get(eq("missing"), any(), isNull()))
+        when(cacheService.get(eq("missing"), isNull()))
                 .thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/cache/get/missing"))
@@ -67,7 +67,7 @@ class CacheControllerTest {
 
     @Test
     void getCache_withTypeParam_usesCorrectClass() throws Exception {
-        when(cacheService.get(eq("counter"), any(), isNull()))
+        when(cacheService.get(eq("counter"), isNull()))
                 .thenReturn(Optional.of(42));
 
         mockMvc.perform(get("/api/cache/get/counter?type=integer"))

--- a/backend/src/test/java/com/example/cache/service/LockDemoOrchestratorTest.java
+++ b/backend/src/test/java/com/example/cache/service/LockDemoOrchestratorTest.java
@@ -44,7 +44,7 @@ class LockDemoOrchestratorTest {
                     DistributedLockService.FencedOperation<Object> op = inv.getArgument(1);
                     return Optional.of(op.execute(1L));
                 });
-        when(cacheService.get(eq("mykey"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("mykey"), isNull()))
                 .thenReturn(Optional.of("hello"));
 
         Optional<Map<String, Object>> result = orchestrator.executeFencedOperation(
@@ -64,7 +64,7 @@ class LockDemoOrchestratorTest {
                     DistributedLockService.FencedOperation<Object> op = inv.getArgument(1);
                     return Optional.of(op.execute(2L));
                 });
-        when(cacheService.get(eq("mykey"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("mykey"), isNull()))
                 .thenReturn(Optional.empty());
 
         Optional<Map<String, Object>> result = orchestrator.executeFencedOperation(
@@ -124,7 +124,7 @@ class LockDemoOrchestratorTest {
                     DistributedLockService.FencedOperation<Object> op = inv.getArgument(1);
                     return Optional.of(op.execute(5L));
                 });
-        when(cacheService.get(eq("ctr"), eq(Integer.class), any()))
+        when(cacheService.get(eq("ctr"), any()))
                 .thenReturn(Optional.of(10));
         when(cacheService.setAsync(eq("ctr"), eq(15), any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
@@ -146,7 +146,7 @@ class LockDemoOrchestratorTest {
                     DistributedLockService.FencedOperation<Object> op = inv.getArgument(1);
                     return Optional.of(op.execute(6L));
                 });
-        when(cacheService.get(eq("k1"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("k1"), isNull()))
                 .thenReturn(Optional.of("old"));
         when(cacheService.setAsync(eq("k1"), eq("new"), any()))
                 .thenReturn(CompletableFuture.completedFuture(true));
@@ -171,7 +171,7 @@ class LockDemoOrchestratorTest {
                     DistributedLockService.FencedOperation<Object> op = inv.getArgument(1);
                     return Optional.of(op.execute(6L));
                 });
-        when(cacheService.get(eq("k1"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("k1"), isNull()))
                 .thenReturn(Optional.of("different"));
 
         Map<String, Object> data = new HashMap<>();
@@ -238,7 +238,7 @@ class LockDemoOrchestratorTest {
                     Supplier<Object> op = inv.getArgument(1);
                     return Optional.of(op.get());
                 });
-        when(cacheService.get(eq("rk"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("rk"), isNull()))
                 .thenReturn(Optional.of("rval"));
 
         Optional<Map<String, Object>> result = orchestrator.executeLockOperation(
@@ -257,7 +257,7 @@ class LockDemoOrchestratorTest {
                     Supplier<Object> op = inv.getArgument(1);
                     return Optional.of(op.get());
                 });
-        when(cacheService.get(eq("rk"), eq(Object.class), isNull()))
+        when(cacheService.get(eq("rk"), isNull()))
                 .thenReturn(Optional.empty());
 
         Optional<Map<String, Object>> result = orchestrator.executeLockOperation(
@@ -296,7 +296,7 @@ class LockDemoOrchestratorTest {
                     Supplier<Object> op = inv.getArgument(1);
                     return Optional.of(op.get());
                 });
-        when(cacheService.get(eq("ctr"), eq(Integer.class), any()))
+        when(cacheService.get(eq("ctr"), any()))
                 .thenReturn(Optional.of(7));
         when(cacheService.setAsync(eq("ctr"), eq(10), any()))
                 .thenReturn(CompletableFuture.completedFuture(true));

--- a/backend/src/test/java/com/example/cache/service/PubSubServiceTest.java
+++ b/backend/src/test/java/com/example/cache/service/PubSubServiceTest.java
@@ -12,6 +12,8 @@ import org.redisson.api.RedissonClient;
 import org.redisson.api.listener.MessageListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.concurrent.ExecutorService;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -21,6 +23,9 @@ class PubSubServiceTest {
 
     @Mock
     RedissonClient redissonClient;
+
+    @Mock
+    ExecutorService virtualThreadExecutor;
 
     @InjectMocks
     PubSubService pubSubService;
@@ -32,6 +37,9 @@ class PubSubServiceTest {
     void setUp() {
         // lenient: not all tests call getTopic (e.g. createEmitter tests)
         lenient().when(redissonClient.getTopic(anyString())).thenReturn(rTopic);
+        // Execute runnables immediately on the calling thread for deterministic tests
+        lenient().doAnswer(inv -> { ((Runnable) inv.getArgument(0)).run(); return null; })
+                .when(virtualThreadExecutor).execute(any(Runnable.class));
     }
 
     @Test

--- a/backend/src/test/java/com/example/cache/service/ResilientCacheServiceIT.java
+++ b/backend/src/test/java/com/example/cache/service/ResilientCacheServiceIT.java
@@ -52,14 +52,14 @@ class ResilientCacheServiceIT {
     @Test
     void setAsync_and_get_roundTrip_string() throws Exception {
         cacheService.setAsync("test:str", "hello", Duration.ofMinutes(5)).get();
-        Optional<String> result = cacheService.get("test:str", String.class, null);
+        Optional<String> result = cacheService.get("test:str", null);
         assertThat(result).isPresent().contains("hello");
     }
 
     @Test
     void setAsync_and_get_roundTrip_integer() throws Exception {
         cacheService.setAsync("test:int", 42, Duration.ofMinutes(5)).get();
-        Optional<Object> result = cacheService.get("test:int", Object.class, null);
+        Optional<Object> result = cacheService.get("test:int", null);
         assertThat(result).isPresent();
     }
 
@@ -69,7 +69,7 @@ class ResilientCacheServiceIT {
         boolean deleted = cacheService.delete("test:del");
         assertThat(deleted).isTrue();
 
-        Optional<String> after = cacheService.get("test:del", String.class, null);
+        Optional<String> after = cacheService.get("test:del", null);
         assertThat(after).isEmpty();
     }
 
@@ -101,7 +101,7 @@ class ResilientCacheServiceIT {
     void getMetrics_recordsOperations() throws Exception {
         cacheService.getMetrics().reset();
         cacheService.setAsync("metrics:test", "v", Duration.ofMinutes(1)).get();
-        cacheService.get("metrics:test", String.class, null);
+        cacheService.get("metrics:test", null);
 
         Map<String, Long> metricsMap = cacheService.getMetrics().toMap();
         assertThat(metricsMap.get("operations")).isGreaterThanOrEqualTo(2L);
@@ -136,7 +136,7 @@ class ResilientCacheServiceIT {
         cacheService.setSimulateError(true);
         for (int i = 0; i < calls; i++) {
             try {
-                cacheService.get("cb-trip:" + i, String.class, null);
+                cacheService.get("cb-trip:" + i, null);
             } catch (RuntimeException ignored) {
                 // CB に失敗を記録させるため、例外を握りつぶす
             }
@@ -166,7 +166,7 @@ class ResilientCacheServiceIT {
 
         // OPEN 状態では CallNotPermittedException → fallback が返る
         cacheService.setSimulateError(false);
-        Optional<String> result = cacheService.get("cb-fallback:key", String.class,
+        Optional<String> result = cacheService.get("cb-fallback:key",
                 () -> "fallback-value");
         assertThat(result).isPresent().contains("fallback-value");
     }
@@ -190,7 +190,7 @@ class ResilientCacheServiceIT {
 
         // HALF_OPEN で permitted-number-of-calls-in-half-open-state=3 回成功させる
         for (int i = 0; i < 3; i++) {
-            Optional<String> probe = cacheService.get("cb-recover:key", String.class, null);
+            Optional<String> probe = cacheService.get("cb-recover:key", null);
             assertThat(probe).isPresent().contains("ok");
         }
 

--- a/backend/src/test/java/com/example/cache/service/ResilientCacheServiceTest.java
+++ b/backend/src/test/java/com/example/cache/service/ResilientCacheServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.cache.service;
 
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -76,6 +77,7 @@ class ResilientCacheServiceTest {
                 redissonClient,
                 circuitBreakerRegistry,
                 retryRegistry,
+                BulkheadRegistry.ofDefaults(),
                 distributedRateLimiter,
                 executor);
     }
@@ -89,7 +91,7 @@ class ResilientCacheServiceTest {
         when(redissonClient.<Object>getBucket("mykey")).thenReturn((RBucket) bucket);
         when(bucket.get()).thenReturn("hello");
 
-        Optional<String> result = service.get("mykey", String.class, null);
+        Optional<String> result = service.get("mykey", null);
 
         assertThat(result).contains("hello");
     }
@@ -99,7 +101,7 @@ class ResilientCacheServiceTest {
         when(redissonClient.<Object>getBucket("missing")).thenReturn((RBucket) bucket);
         when(bucket.get()).thenReturn(null);
 
-        Optional<String> result = service.get("missing", String.class, null);
+        Optional<String> result = service.get("missing", null);
 
         assertThat(result).isEmpty();
     }
@@ -109,7 +111,7 @@ class ResilientCacheServiceTest {
         when(redissonClient.<Object>getBucket("anykey")).thenReturn((RBucket) bucket);
         when(bucket.get()).thenThrow(new RedisConnectionException("connection refused"));
 
-        Optional<String> result = service.get("anykey", String.class, () -> "fallback-value");
+        Optional<String> result = service.get("anykey", () -> "fallback-value");
 
         assertThat(result).contains("fallback-value");
     }
@@ -119,7 +121,7 @@ class ResilientCacheServiceTest {
         when(redissonClient.<Object>getBucket("anykey")).thenReturn((RBucket) bucket);
         when(bucket.get()).thenThrow(new RedisConnectionException("connection refused"));
 
-        Optional<String> result = service.get("anykey", String.class, null);
+        Optional<String> result = service.get("anykey", null);
 
         assertThat(result).isEmpty();
     }
@@ -129,7 +131,7 @@ class ResilientCacheServiceTest {
         when(redissonClient.<Object>getBucket("anykey")).thenReturn((RBucket) bucket);
         when(bucket.get()).thenThrow(new RedisConnectionException("connection refused"));
 
-        Optional<String> result = service.get("anykey", String.class, () -> {
+        Optional<String> result = service.get("anykey", () -> {
             throw new RuntimeException("fallback also failed");
         });
 


### PR DESCRIPTION
## Summary
- `warmUp` メソッドをシリアル実行から `CompletableFuture.allOf` による真の並行実行に修正
- `PubSubService.broadcastToEmitters` を Netty スレッドから `virtualExecutor` にディスパッチ
- `ResilientCacheService.get()` の未使用 `Class<T> type` パラメータを削除
- `CacheController` / `LockController` に Java 16+ の pattern matching for instanceof を適用
- Resilience4j `SemaphoreBulkhead` を導入し全 Redis 操作に適用（Virtual Threads 環境でのリソース保護）

## Test plan
- [x] `./gradlew test` — 460 tests passed
- [x] `./gradlew compileJava` — compilation successful

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)