### PR TITLE
fix: FE Mid — コンポーネント品質改善 (#40)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { RateLimiterPage }      from './pages/RateLimiterPage';
 import { PubSubPage }           from './pages/PubSubPage';
 import { SagaTracerPage }       from './pages/SagaTracerPage';
 import { RedisCliPage }         from './pages/RedisCliPage';
+import { NotFoundPage }         from './pages/NotFoundPage';
 
 export default function App() {
   return (
@@ -35,7 +36,7 @@ export default function App() {
           <Route path="/pubsub"          element={<PubSubPage />} />
           <Route path="/saga"            element={<SagaTracerPage />} />
           <Route path="/cli"             element={<RedisCliPage />} />
-          <Route path="*"               element={<div className="p-8 text-center"><h2 className="text-xl font-bold mb-4">404 - ページが見つかりません</h2><a href="/" className="text-blue-400 hover:text-blue-300 underline">ホームに戻る</a></div>} />
+          <Route path="*"               element={<NotFoundPage />} />
         </Routes>
         </ErrorBoundary>
       </AppShell>

--- a/frontend/src/api/pubsub.ts
+++ b/frontend/src/api/pubsub.ts
@@ -1,5 +1,4 @@
-import { apiFetch } from './client';
-import { getBaseUrl } from './client';
+import { apiFetch, getBaseUrl } from './client';
 
 export const pubsubApi = {
   publish: (topic: string, message: string) =>

--- a/frontend/src/components/metrics/CacheMetricsPanel.tsx
+++ b/frontend/src/components/metrics/CacheMetricsPanel.tsx
@@ -1,5 +1,6 @@
 import type { CacheMetrics } from '../../types/cache';
 import { MetricsDonutChart } from './MetricsDonutChart';
+import { MetricsTrendChart } from './MetricsTrendChart';
 
 interface Props {
   data: CacheMetrics | null;
@@ -9,7 +10,12 @@ interface Props {
 
 const DONUT_COLORS = ['#10B981', '#F59E0B', '#EF4444'];
 
-export function CacheMetricsPanel({ data, isLoading, trendData: _trendData }: Props) {
+const TREND_LINES = [
+  { dataKey: 'operations', color: '#60A5FA', label: '操作数' },
+  { dataKey: 'hits', color: '#10B981', label: 'ヒット数' },
+];
+
+export function CacheMetricsPanel({ data, isLoading, trendData }: Props) {
   if (isLoading) {
     return (
       <div className="bg-gray-800 rounded-lg p-4">
@@ -59,6 +65,11 @@ export function CacheMetricsPanel({ data, isLoading, trendData: _trendData }: Pr
       <div>
         <h3 className="text-gray-400 text-sm mb-2">操作の内訳</h3>
         <MetricsDonutChart data={donutData} height={220} />
+      </div>
+
+      <div className="mt-4">
+        <h3 className="text-gray-400 text-sm mb-2">トレンド</h3>
+        <MetricsTrendChart data={trendData} lines={TREND_LINES} height={200} />
       </div>
     </div>
   );

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,10 @@
+export function NotFoundPage() {
+  return (
+    <div className="p-8 text-center">
+      <h2 className="text-xl font-bold mb-4">404 - ページが見つかりません</h2>
+      <a href="/" className="text-blue-400 hover:text-blue-300 underline">
+        ホームに戻る
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/test/pages/NotFoundPage.test.tsx
+++ b/frontend/src/test/pages/NotFoundPage.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NotFoundPage } from '../../pages/NotFoundPage'
+
+describe('NotFoundPage', () => {
+  it('renders 404 message', () => {
+    render(<NotFoundPage />)
+    expect(screen.getByText(/404/)).toBeInTheDocument()
+    expect(screen.getByText(/ページが見つかりません/)).toBeInTheDocument()
+  })
+
+  it('renders home link', () => {
+    render(<NotFoundPage />)
+    const link = screen.getByRole('link', { name: /ホームに戻る/ })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})


### PR DESCRIPTION
## Summary
- `CacheMetricsPanel`: 未使用だった `trendData` プロップを `MetricsTrendChart` に結線
- 404ルート: インラインJSXを `NotFoundPage` コンポーネントに分離、テスト追加
- `pubsub.ts`: 同一モジュール `./client` からのダブルインポートを1行に統合

## Test plan
- [x] `npm test` — 641 tests passed
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — successful

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)