### PR TITLE
fix: FE Low — Hook改善, 型安全性強化, テスト衛生改善 (#46)

### DIFF
--- a/frontend/src/api/cache.ts
+++ b/frontend/src/api/cache.ts
@@ -2,6 +2,7 @@ import { apiFetch } from './client';
 import type {
   CacheGetResponse, CacheSetRequest, CacheBatchGetResponse,
   CacheBatchSetEntry, CacheDeleteResponse, CacheMetrics,
+  CacheSetResponse, CacheBatchSetResponse, CacheSearchResponse,
 } from '../types/cache';
 
 export const cacheApi = {
@@ -11,7 +12,7 @@ export const cacheApi = {
     ),
 
   set: (key: string, body: CacheSetRequest) =>
-    apiFetch<{ key: string; success: boolean; ttl: string }>(
+    apiFetch<CacheSetResponse>(
       `/api/cache/set/${encodeURIComponent(key)}`,
       { method: 'POST', body: JSON.stringify(body) }
     ),
@@ -22,7 +23,7 @@ export const cacheApi = {
     ),
 
   batchSet: (entries: CacheBatchSetEntry[]) =>
-    apiFetch<{ total: number; successful: number; failed: number }>(
+    apiFetch<CacheBatchSetResponse>(
       '/api/cache/batch',
       { method: 'POST', body: JSON.stringify(entries) }
     ),
@@ -40,7 +41,7 @@ export const cacheApi = {
     ),
 
   searchKeys: (pattern = '*', limit = 100) =>
-    apiFetch<{ pattern: string; limit: number; count: number; keys: string[] }>(
+    apiFetch<CacheSearchResponse>(
       `/api/cache/search?pattern=${encodeURIComponent(pattern)}&limit=${limit}`
     ),
 

--- a/frontend/src/api/cli.ts
+++ b/frontend/src/api/cli.ts
@@ -1,12 +1,7 @@
 import { apiFetch } from './client';
+import type { CliResponse } from '../types/cli';
 
-export interface CliResponse {
-  command: string;
-  result?: string;
-  error?: string;
-  executionMs: number;
-  timestamp: number;
-}
+export type { CliResponse };
 
 export const cliApi = {
   execute: (command: string) =>

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,10 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 const FOCUSABLE_SELECTOR = 'a[href], button:not(:disabled), textarea:not(:disabled), input:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])';
 
 export function useFocusTrap(isOpen: boolean, onClose?: () => void) {
   const containerRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
+
+  // onClose を ref で保持することで、呼び出し側がインラインの arrow function を渡しても
+  // useEffect が再実行されない（listener の過剰な登録・削除を防ぐ）。
+  // useLayoutEffect で同期的に更新することで render 外での代入ルールを満たす。
+  const onCloseRef = useRef(onClose);
+  useLayoutEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (!isOpen) return;
@@ -22,9 +30,9 @@ export function useFocusTrap(isOpen: boolean, onClose?: () => void) {
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && onClose) {
+      if (e.key === 'Escape' && onCloseRef.current) {
         e.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
 
@@ -58,7 +66,7 @@ export function useFocusTrap(isOpen: boolean, onClose?: () => void) {
         previousFocusRef.current.focus();
       }
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]); // onClose は ref 経由で参照するため依存配列に含めない
 
   return containerRef;
 }

--- a/frontend/src/hooks/usePolling.ts
+++ b/frontend/src/hooks/usePolling.ts
@@ -22,13 +22,20 @@ export function usePolling<T>({
   const [error, setError] = useState<string | null>(null);
   // enabled=false のときは即座にロード完了とみなす（ポーリング自体が行われないため）
   const [isLoading, setIsLoading] = useState(enabled);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // fetcher を ref で保持することで、呼び出し側が useCallback を使わずに
   // インラインで fetcher を渡しても useEffect が再実行されない。
   // これにより fetcher の参照が変わるたびにポーリングが重複登録されるバグを防ぐ。
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
+
+  // enabledRef / intervalRef を保持することで、setTimeout コールバック内から
+  // 最新の値を参照できる（クロージャの stale 問題を回避）。
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const intervalRef = useRef(interval);
+  intervalRef.current = interval;
 
   const run = useCallback(async () => {
     try {
@@ -39,15 +46,18 @@ export function usePolling<T>({
       setError(e instanceof Error ? e.message : '取得失敗');
     } finally {
       setIsLoading(false);
+      // fetch 完了後に次回タイマーを再アーム（fetch が interval より長くかかっても重複しない）
+      if (enabledRef.current) {
+        timerRef.current = setTimeout(run, intervalRef.current);
+      }
     }
-  }, []); // fetcherRef は ref なので依存配列に含めない
+  }, []); // fetcherRef / enabledRef / intervalRef は ref なので依存配列に含めない
 
   useEffect(() => {
     if (!enabled) return;
     run();
-    timerRef.current = setInterval(run, interval);
     return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
+      if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [enabled, interval, run]);
 

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -17,6 +17,8 @@ export function useToast() {
     setToasts(prev => [...prev, { id, message, variant }]);
     const timerId = setTimeout(() => {
       setToasts(prev => prev.filter(t => t.id !== id));
+      // 発火済みの timer ID を配列から除去して unbounded growth を防ぐ
+      timerIdsRef.current = timerIdsRef.current.filter(tid => tid !== timerId);
     }, 3000);
     timerIdsRef.current.push(timerId);
   }, []);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { RefreshCw, Activity, Percent, Hash, ShieldCheck } from 'lucide-react';
 import { usePolling } from '../hooks/usePolling';
@@ -14,22 +14,20 @@ export function DashboardPage() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const navigate = useNavigate();
 
-  const healthFetcher = useCallback(() => healthApi.get(), []);
-  const cacheFetcher = useCallback(() => cacheApi.metrics(), []);
-  const locksFetcher = useCallback(() => locksApi.metrics(), []);
-
+  // usePolling が fetcherRef パターンで参照を安定化するため、
+  // インライン関数を直接渡しても useEffect が再実行されない。
   const { data: health, refetch: refetchHealth } = usePolling({
-    fetcher: healthFetcher,
+    fetcher: () => healthApi.get(),
     interval: 10000,
     enabled: autoRefresh,
   });
   const { data: cache, refetch: refetchCache } = usePolling({
-    fetcher: cacheFetcher,
+    fetcher: () => cacheApi.metrics(),
     interval: 15000,
     enabled: autoRefresh,
   });
   const { data: locks, refetch: refetchLocks } = usePolling({
-    fetcher: locksFetcher,
+    fetcher: () => locksApi.metrics(),
     interval: 15000,
     enabled: autoRefresh,
   });

--- a/frontend/src/pages/RedisVisualizerPage.tsx
+++ b/frontend/src/pages/RedisVisualizerPage.tsx
@@ -191,7 +191,7 @@ export function RedisVisualizerPage() {
 
   useEffect(() => {
     loadKeys('*');
-  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);  // eslint-disable-line react-hooks/exhaustive-deps -- loadKeys depends on `selected` state; including it would re-fetch on every selection change
 
   const handleDelete = async (key: string) => {
     setIsDeleting(true);

--- a/frontend/src/test/hooks/usePolling.test.ts
+++ b/frontend/src/test/hooks/usePolling.test.ts
@@ -88,13 +88,19 @@ describe('usePolling', () => {
     expect(fetcher).toHaveBeenCalledTimes(2)
   })
 
-  it('clears interval on unmount', () => {
-    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+  it('clears timeout on unmount', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
     const fetcher = vi.fn().mockResolvedValue({})
     const { unmount } = renderHook(() => usePolling({ fetcher, interval: 1000 }))
 
+    // Wait for the initial fetch to complete so setTimeout is scheduled
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
     unmount()
 
-    expect(clearIntervalSpy).toHaveBeenCalled()
+    expect(clearTimeoutSpy).toHaveBeenCalled()
   })
 })

--- a/frontend/src/test/pages/CacheExplorerPage.test.tsx
+++ b/frontend/src/test/pages/CacheExplorerPage.test.tsx
@@ -150,7 +150,7 @@ describe('CacheExplorerPage', () => {
       },
     })
     mockDelete.mockResolvedValue({ key: 'demo:greeting', deleted: true })
-    mockSet.mockResolvedValue({ key: 'new:key', success: true })
+    mockSet.mockResolvedValue({ key: 'new:key', success: true, ttl: 'PT1H' })
     mockWarmup.mockResolvedValue({ status: 'DONE', keys: 2 })
   })
 

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -60,6 +60,8 @@ describe('DashboardPage', () => {
     vi.clearAllMocks()
     mockHealthGet.mockResolvedValue({
       status: 'UP',
+      timestamp: new Date().toISOString(),
+      service: 'redis-app',
       redis: { status: 'UP', initialized: true },
       circuitBreakers: {
         'cache-operations': {
@@ -176,6 +178,8 @@ describe('DashboardPage', () => {
   it('shows DOWN value when redis is down', async () => {
     mockHealthGet.mockResolvedValue({
       status: 'DOWN',
+      timestamp: new Date().toISOString(),
+      service: 'redis-app',
       redis: { status: 'DOWN', initialized: true },
       circuitBreakers: {},
     })
@@ -185,7 +189,7 @@ describe('DashboardPage', () => {
     })
   })
 
-  it('shows N/A when data not yet loaded', () => {
+  it('shows 0% when data not yet loaded', () => {
     // Override with never-resolving promise so initial state stays empty
     mockHealthGet.mockReturnValue(new Promise(() => {}))
     mockCacheMetrics.mockReturnValue(new Promise(() => {}))

--- a/frontend/src/test/pages/MetricsPage.test.tsx
+++ b/frontend/src/test/pages/MetricsPage.test.tsx
@@ -190,7 +190,7 @@ describe('MetricsPage', () => {
       vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
         const el = origCreateElement(tag)
         if (tag === 'a') {
-          vi.spyOn(el as HTMLElement, 'click').mockImplementation(anchorClickSpy)
+          vi.spyOn(el as HTMLElement, 'click').mockImplementation(anchorClickSpy as () => void)
         }
         return el
       })

--- a/frontend/src/test/pages/PubSubPage.test.tsx
+++ b/frontend/src/test/pages/PubSubPage.test.tsx
@@ -3,12 +3,6 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { PubSubPage } from '../../pages/PubSubPage'
 
-// jsdom does not implement HTMLElement.scrollTo — mock it globally for this suite
-Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
-  writable: true,
-  value: vi.fn(),
-})
-
 // Mock pubsubApi
 vi.mock('../../api/pubsub', () => ({
   pubsubApi: {

--- a/frontend/src/test/pages/RateLimiterPage.test.tsx
+++ b/frontend/src/test/pages/RateLimiterPage.test.tsx
@@ -53,7 +53,7 @@ const mockFloodResult = {
     { workerId: 1, permitted: true, relativeMs: 0 },
     { workerId: 2, permitted: false, relativeMs: 5 },
   ],
-  timestamp: '2026-04-04T00:00:00Z',
+  timestamp: Date.parse('2026-04-04T00:00:00Z'),
 }
 
 function renderPage() {

--- a/frontend/src/test/pages/RedisVisualizerPage.test.tsx
+++ b/frontend/src/test/pages/RedisVisualizerPage.test.tsx
@@ -27,6 +27,8 @@ const defaultSearchResult = {
 }
 
 const defaultBatchGetResult = {
+  requested: 3,
+  found: 3,
   results: {
     'cache:user:1': 'Alice',
     'cache:user:2': 'Bob',
@@ -432,6 +434,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['user:profile'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'user:profile': { name: 'Alice', age: 30, role: 'admin' },
         },
@@ -457,6 +461,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['queue:tasks'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'queue:tasks': ['task1', 'task2', 'task3'],
         },
@@ -478,6 +484,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['queue:tasks'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'queue:tasks': ['task1', 'task2'],
         },
@@ -501,6 +509,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['leaderboard'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'leaderboard': [
             { m: 'player1', s: 100 },
@@ -527,6 +537,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['events:stream'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'events:stream': [
             { id: '1700000000-0', fields: { event: 'click' } },
@@ -558,6 +570,8 @@ describe('RedisVisualizerPage', () => {
       // we need to test the TTLBar sub-component behavior directly via StringValue values.
       // We only verify that the page renders without error for coverage.
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: { 'ttl:key': `value-with-ttl-${ttl}` },
       })
       renderPage()
@@ -581,6 +595,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['str:key', 'hash:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'str:key': 'hello',
           'hash:key': { field1: 'value1' },
@@ -611,6 +627,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['hash:key', 'str:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'hash:key': { field1: 'value1' },
           'str:key': 'hello',
@@ -639,6 +657,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['str:key', 'hash:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'str:key': 'hello',
           'hash:key': { field1: 'value1' },
@@ -679,6 +699,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['list:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'list:key': ['a', 'b', 'c'],
         },
@@ -700,6 +722,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['hash:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: {
           'hash:key': { name: 'Alice', role: 'admin' },
         },
@@ -721,6 +745,8 @@ describe('RedisVisualizerPage', () => {
         keys: ['str:key'],
       })
       mockBatchGet.mockResolvedValue({
+        requested: 1,
+        found: 1,
         results: { 'str:key': 'hello' },
       })
       renderPage()
@@ -745,8 +771,8 @@ describe('RedisVisualizerPage', () => {
       mockSearchKeys.mockResolvedValue({ pattern: '*', limit: 200, count: 60, keys })
       // First chunk (0..49), second chunk (50..59)
       mockBatchGet
-        .mockResolvedValueOnce({ results: Object.fromEntries(keys.slice(0, 50).map(k => [k, results[k]])) })
-        .mockResolvedValueOnce({ results: Object.fromEntries(keys.slice(50).map(k => [k, results[k]])) })
+        .mockResolvedValueOnce({ requested: 50, found: 50, results: Object.fromEntries(keys.slice(0, 50).map(k => [k, results[k]])) })
+        .mockResolvedValueOnce({ requested: 10, found: 10, results: Object.fromEntries(keys.slice(50).map(k => [k, results[k]])) })
 
       renderPage()
       await waitFor(() => {

--- a/frontend/src/test/pages/SagaTracerPage.test.tsx
+++ b/frontend/src/test/pages/SagaTracerPage.test.tsx
@@ -32,24 +32,24 @@ const mockRunSagaFail = vi.mocked(transactionApi.runSagaFail)
 
 const mockSuccessResult = {
   steps: [
-    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12 },
-    { name: 'PaymentProcessed', status: 'SUCCESS' as const, durationMs: 34 },
-    { name: 'InventoryReserved', status: 'SUCCESS' as const, durationMs: 8 },
+    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12, detail: '' },
+    { name: 'PaymentProcessed', status: 'SUCCESS' as const, durationMs: 34, detail: '' },
+    { name: 'InventoryReserved', status: 'SUCCESS' as const, durationMs: 8, detail: '' },
   ],
   overallStatus: 'SUCCESS' as const,
-  timestamp: '2026-04-04T00:00:00Z',
+  timestamp: Date.parse('2026-04-04T00:00:00Z'),
 }
 
 const mockFailResult = {
   steps: [
-    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12 },
-    { name: 'PaymentProcessed', status: 'FAILED' as const, durationMs: 5 },
+    { name: 'OrderCreated', status: 'SUCCESS' as const, durationMs: 12, detail: '' },
+    { name: 'PaymentProcessed', status: 'FAILED' as const, durationMs: 5, detail: 'error' },
   ],
   compensationSteps: [
-    { name: 'OrderCancelled', status: 'COMPENSATED' as const, durationMs: 9 },
+    { name: 'OrderCancelled', status: 'COMPENSATED' as const, durationMs: 9, detail: '' },
   ],
   overallStatus: 'COMPENSATED' as const,
-  timestamp: '2026-04-04T00:00:00Z',
+  timestamp: Date.parse('2026-04-04T00:00:00Z'),
 }
 
 function renderPage() {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+// jsdom does not implement HTMLElement.scrollTo — mock it globally for all suites
+Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+  writable: true,
+  value: () => {},
+})
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())

--- a/frontend/src/types/cache.ts
+++ b/frontend/src/types/cache.ts
@@ -1,7 +1,7 @@
 export interface CacheGetResponse {
   key: string;
   found: boolean;
-  value: unknown | null;
+  value: unknown;
 }
 
 export interface CacheSetRequest {
@@ -24,6 +24,25 @@ export interface CacheBatchSetEntry {
 export interface CacheDeleteResponse {
   key: string;
   deleted: boolean;
+}
+
+export interface CacheSetResponse {
+  key: string;
+  success: boolean;
+  ttl: string;
+}
+
+export interface CacheBatchSetResponse {
+  total: number;
+  successful: number;
+  failed: number;
+}
+
+export interface CacheSearchResponse {
+  pattern: string;
+  limit: number;
+  count: number;
+  keys: string[];
 }
 
 export interface CacheMetrics {

--- a/frontend/src/types/cli.ts
+++ b/frontend/src/types/cli.ts
@@ -1,0 +1,7 @@
+export interface CliResponse {
+  command: string;
+  result?: string;
+  error?: string;
+  executionMs: number;
+  timestamp: number;
+}

--- a/frontend/src/types/locks.ts
+++ b/frontend/src/types/locks.ts
@@ -40,7 +40,6 @@ export interface FencedLockResponse {
   acquired: boolean;
   fencingToken: number | null;
   timestamp: number;
-  [key: string]: unknown;
 }
 
 export interface LockExecuteResponse {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src/test/**/*.ts", "src/test/**/*.tsx"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- **[Medium]** `usePolling`: `setInterval`→`setTimeout` re-arm方式（リクエスト重複防止）
- **[Medium]** `useFocusTrap`: `onClose`をrefパターン化（listener再登録防止）
- `useToast`: 発火済みtimer IDクリーンアップ
- `FencedLockResponse`のindex signature削除
- `CliResponse`型を`types/cli.ts`に移動
- `CacheGetResponse.value`を`unknown`に簡素化
- `api/cache.ts`インライン型を`types/cache.ts`に抽出
- `DashboardPage`不要な`useCallback`削除
- `tsconfig.test.json`新規作成（テスト型チェック有効化）
- テスト衛生: `onUnhandledRequest: 'error'`、`scrollTo`パッチ集約、テスト名修正

## Test plan
- [x] `npm run build` — ビルド成功
- [x] `npm run lint` — リントエラーなし
- [x] `npm test` — 全641テスト通過
- [ ] CI で全テスト通過確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)