### PR TITLE
fix: Infra Low — セキュリティ強化 + 可観測性改善 + CI最適化 (#47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
     needs: [backend, frontend]
+    env:
+      GRAFANA_ADMIN_PASSWORD: ci-test-password
     steps:
       - uses: actions/checkout@v4
 
       - name: Build and start services
-        env:
-          GRAFANA_ADMIN_PASSWORD: ci-test-password
         run: |
           docker compose build
           docker compose up -d
@@ -106,16 +106,29 @@ jobs:
           cache: npm
           cache-dependency-path: e2e/package-lock.json
 
-      - name: Install Playwright
+      - name: Install E2E dependencies
         working-directory: e2e
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: e2e
+        run: npx playwright install-deps chromium
 
       - name: Run E2E tests
         working-directory: e2e
-        env:
-          GRAFANA_ADMIN_PASSWORD: ci-test-password
         run: npx playwright test
 
       - name: Upload Playwright report
@@ -127,6 +140,4 @@ jobs:
 
       - name: Stop services
         if: always()
-        env:
-          GRAFANA_ADMIN_PASSWORD: ci-test-password
         run: docker compose down

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,3 +2,5 @@
 build/
 src/test/
 *.md
+.git/
+.idea/

--- a/backend/src/main/java/com/example/cache/config/ApiKeyAuthFilter.java
+++ b/backend/src/main/java/com/example/cache/config/ApiKeyAuthFilter.java
@@ -28,7 +28,7 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
     public ApiKeyAuthFilter(@Value("${api.key:}") String apiKey) {
         this.apiKey = apiKey;
         if (apiKey.isEmpty()) {
-            log.warn("API_KEY is not configured. All requests will be granted DEMO_ADMIN access. "
+            log.error("API_KEY is not configured. All requests will be granted DEMO_ADMIN access. "
                     + "Set API_KEY environment variable for production use.");
         }
     }

--- a/backend/src/main/java/com/example/cache/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/cache/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/cache/simulate-error", "/api/cache/reset-circuit-breaker").hasRole("DEMO_ADMIN")
                 .requestMatchers("/api/lock/release").hasRole("DEMO_ADMIN")
                 .requestMatchers("/api/**").authenticated()
-                .anyRequest().permitAll()
+                .anyRequest().denyAll()
             )
             .addFilterBefore(apiKeyFilter, UsernamePasswordAuthenticationFilter.class)
             .build();

--- a/backend/src/main/java/com/example/cache/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/cache/config/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/health/**", "/actuator/health/**").permitAll()
                 .requestMatchers("/actuator/**").authenticated()
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
                 .requestMatchers("/api/cache/simulate-error", "/api/cache/reset-circuit-breaker").hasRole("DEMO_ADMIN")
                 .requestMatchers("/api/lock/release").hasRole("DEMO_ADMIN")
                 .requestMatchers("/api/**").authenticated()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "80:8080"
+      - "127.0.0.1:80:8080"
     mem_limit: 128m
     cpus: '0.5'
     depends_on:
@@ -102,6 +102,8 @@ services:
       - "127.0.0.1:16686:16686"
     mem_limit: 512m
     cpus: '0.5'
+    volumes:
+      - jaeger-data:/tmp/jaeger
     networks:
       - monitoring
 
@@ -123,6 +125,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--web.enable-remote-write-receiver'
+      - '--storage.tsdb.retention.time=7d'
     volumes:
       - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./docker/alert-rules.yml:/etc/prometheus/alert-rules.yml
@@ -171,3 +174,4 @@ volumes:
   prometheus-data:
   grafana-data:
   loki-data:
+  jaeger-data:

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -5,7 +5,7 @@ providers:
     orgId: 1
     folder: ''
     type: file
-    disableDeletion: false
+    disableDeletion: true
     updateIntervalSeconds: 30
     options:
       path: /var/lib/grafana/dashboards

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -13,3 +13,9 @@ datasources:
     access: proxy
     url: http://loki:3100
     editable: false
+
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false

--- a/docker/otel-collector-config.yaml
+++ b/docker/otel-collector-config.yaml
@@ -34,12 +34,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug, otlp/jaeger]
+      exporters: [otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug, prometheusremotewrite]
+      exporters: [prometheusremotewrite]
     logs:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug, loki]
+      exporters: [loki]


### PR DESCRIPTION
## Summary
- **[High]** `SecurityConfig`: `.anyRequest().permitAll()`→`.denyAll()`（未定義パス明示拒否）
- **[High]** `ApiKeyAuthFilter`: 空API_KEY時ログをERRORに昇格
- `backend/.dockerignore`: `.git/`, `.idea/`除外追加
- `docker-compose`: frontendポートloopbackバインド化
- Grafana: Jaeger datasource追加（トレース⇔メトリクス相関）
- Grafana: dashboard `disableDeletion: true`
- OTel Collector: `debug` exporterを全パイプラインから除去
- Prometheus: retention 7d明記
- Jaeger: trace永続化volume追加
- CI: Playwright browserキャッシュ追加
- CI: `GRAFANA_ADMIN_PASSWORD`をjob-level envに集約

## Test plan
- [x] `./gradlew compileJava` — コンパイル成功
- [x] `./gradlew test` — 全426ユニットテスト通過
- [x] `docker compose config --quiet` — 構文検証OK
- [ ] CI で全テスト+E2E通過確認

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)